### PR TITLE
Add support for displayTimeZone of DateTime element

### DIFF
--- a/Kontent.Ai.Management.Tests/CodeSamples/CmApiV2.cs
+++ b/Kontent.Ai.Management.Tests/CodeSamples/CmApiV2.cs
@@ -1643,7 +1643,8 @@ public class CmApiV2 : IClassFixture<FileSystemFixture>
                     new DateTimeElement
                     {
                         Element = Reference.ByCodename("post_date"),
-                        Value = DateTime.Parse("2014-11-07T00:00:00Z")
+                        Value = DateTime.Parse("2014-11-07T00:00:00Z"),
+                        DisplayTimeZone = "Australia/Sydney"
                     },
                     new TextElement
                     {
@@ -1757,7 +1758,8 @@ public class CmApiV2 : IClassFixture<FileSystemFixture>
         // Scheduled publish
         var scheduledPublishException = await Record.ExceptionAsync(async () => await client.SchedulePublishingOfLanguageVariantAsync(identifier, new ScheduleModel
         {
-            ScheduleTo = DateTime.Parse("2038-01-19T04:14:08+01:00")
+            ScheduleTo = DateTime.Parse("2038-01-19T04:14:08+01:00"),
+            DisplayTimeZone = "Europe/London"
         }));
 
         Assert.Null(immediateException);
@@ -1784,7 +1786,8 @@ public class CmApiV2 : IClassFixture<FileSystemFixture>
         // Scheduled unpublish
         var scheduledUnpublishException = await Record.ExceptionAsync(async () => await client.ScheduleUnpublishingOfLanguageVariantAsync(identifier, new ScheduleModel
         {
-            ScheduleTo = DateTime.Parse("2038-01-19T04:14:08+01:00")
+            ScheduleTo = DateTime.Parse("2038-01-19T04:14:08+01:00"),
+            DisplayTimeZone = "Europe/London"
         }));
 
         Assert.Null(immediateException);

--- a/Kontent.Ai.Management.Tests/CodeSamples/Readme.cs
+++ b/Kontent.Ai.Management.Tests/CodeSamples/Readme.cs
@@ -97,7 +97,7 @@ public class Readme : IClassFixture<FileSystemFixture>
         var response = await client.GetLanguageVariantAsync<ArticleModel>(identifier);
 
         response.Elements.Title = new TextElement() { Value = "On Roasts - changed" };
-        response.Elements.PostDate = new DateTimeElement() { Value = new DateTime(2018, 7, 4) };
+        response.Elements.PostDate = new DateTimeElement() { Value = new DateTime(2018, 7, 4), DisplayTimeZone = "Europe/Prague" };
 
         // Remove next line in codesample
         client = _fileSystemFixture.CreateMockClientWithResponse("ArticleLanguageVariantUpdatedResponse.json");
@@ -166,7 +166,8 @@ public class Readme : IClassFixture<FileSystemFixture>
             {
                 // You can use `Reference.ById` if you don't have the model
                 Element = Reference.ById(typeof(ArticleModel).GetProperty(nameof(ArticleModel.PostDate)).GetKontentElementId()),
-                Value = new DateTime(2018, 7, 4)
+                Value = new DateTime(2018, 7, 4),
+                DisplayTimeZone = "Europe/Prague"
             },
         });
 
@@ -187,7 +188,7 @@ public class Readme : IClassFixture<FileSystemFixture>
         var stronglyTypedElements = new ArticleModel
         {
             Title = new TextElement() { Value = "On Roasts - changed" },
-            PostDate = new DateTimeElement() { Value = new DateTime(2018, 7, 4) },
+            PostDate = new DateTimeElement() { Value = new DateTime(2018, 7, 4), DisplayTimeZone = "Europe/London" },
         };
 
         // Specifies the content item and the language variant

--- a/Kontent.Ai.Management.Tests/Data/Asset/Asset.json
+++ b/Kontent.Ai.Management.Tests/Data/Asset/Asset.json
@@ -86,7 +86,8 @@
       "element": {
         "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
       },
-      "value": "2017-07-04T00:00:00Z"
+      "value": "2017-07-04T00:00:00Z",
+      "display_timezone": null
     },
     {
       "element": {

--- a/Kontent.Ai.Management.Tests/Data/Asset/AssetsPage1.json
+++ b/Kontent.Ai.Management.Tests/Data/Asset/AssetsPage1.json
@@ -88,7 +88,8 @@
           "element": {
             "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
           },
-          "value": "2017-07-04T00:00:00Z"
+          "value": "2017-07-04T00:00:00Z",
+          "display_timezone": null
         },
         {
           "element": {

--- a/Kontent.Ai.Management.Tests/Data/Asset/AssetsPage2.json
+++ b/Kontent.Ai.Management.Tests/Data/Asset/AssetsPage2.json
@@ -88,7 +88,8 @@
           "element": {
             "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
           },
-          "value": "2017-07-04T00:00:00Z"
+          "value": "2017-07-04T00:00:00Z",
+          "display_timezone": null
         },
         {
           "element": {

--- a/Kontent.Ai.Management.Tests/Data/Asset/AssetsPage3.json
+++ b/Kontent.Ai.Management.Tests/Data/Asset/AssetsPage3.json
@@ -88,7 +88,8 @@
           "element": {
             "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
           },
-          "value": "2017-07-04T00:00:00Z"
+          "value": "2017-07-04T00:00:00Z",
+          "display_timezone": null
         },
         {
           "element": {

--- a/Kontent.Ai.Management.Tests/Data/CodeSamples/Readme/ArticleLanguageVariantResponse.json
+++ b/Kontent.Ai.Management.Tests/Data/CodeSamples/Readme/ArticleLanguageVariantResponse.json
@@ -10,7 +10,8 @@
       "element": {
         "id": "abe785d6-9146-4cab-8096-cba555d3840f"
       },
-      "value": "2017-07-04T00:00:00Z"
+      "value": "2017-07-04T00:00:00Z",
+      "display_timezone": null
     },
     {
       "components": [

--- a/Kontent.Ai.Management.Tests/Data/CodeSamples/Readme/ArticleLanguageVariantUpdatedResponse.json
+++ b/Kontent.Ai.Management.Tests/Data/CodeSamples/Readme/ArticleLanguageVariantUpdatedResponse.json
@@ -10,7 +10,8 @@
       "element": {
         "id": "abe785d6-9146-4cab-8096-cba555d3840f"
       },
-      "value": "2018-07-04T00:00:00Z"
+      "value": "2018-07-04T00:00:00Z",
+      "display_timezone": "Europe/Prague"
     },
     {
       "components": [

--- a/Kontent.Ai.Management.Tests/Data/ElementsData.cs
+++ b/Kontent.Ai.Management.Tests/Data/ElementsData.cs
@@ -25,7 +25,7 @@ internal static class ElementsData
             GetElementAsDynamic(complexModel.MetaKeywords.Element.Id, complexModel.MetaKeywords.Value),
             GetArrayElementAsDynamic(complexModel.Options.Element.Id, complexModel.Options.Value),
             GetArrayElementAsDynamic(complexModel.Personas.Element.Id, complexModel.Personas.Value),
-            GetElementAsDynamic(complexModel.PostDate.Element.Id, complexModel.PostDate.Value),
+            GetDateTimeAsDynamic(complexModel.PostDate.Element.Id, complexModel.PostDate.Value, complexModel.PostDate.DisplayTimeZone),
             GetArrayElementAsDynamic(complexModel.RelatedArticles.Element.Id, complexModel.RelatedArticles.Value),
             GetElementAsDynamic(complexModel.Rating.Element.Id, complexModel.Rating.Value),
             GetCustomElementAsDynamic(complexModel.SelectedForm.Element.Id, complexModel.SelectedForm.Value, complexModel.SelectedForm.SearchableValue),
@@ -80,7 +80,8 @@ internal static class ElementsData
         PostDate = new DateTimeElement
         {
             Element = Reference.ById(typeof(ComplexTestModel).GetProperty(nameof(ComplexTestModel.PostDate)).GetKontentElementId()),
-            Value = new DateTime(2017, 7, 4)
+            Value = new DateTime(2017, 7, 4),
+            DisplayTimeZone = null
         },
         RelatedArticles = new LinkedItemsElement
         {
@@ -223,6 +224,16 @@ internal static class ElementsData
         element.element = GetElement(elementId.Value.ToString("d"));
         element.value = value;
         element.mode = mode;
+
+        return element;
+    }
+
+    private static dynamic GetDateTimeAsDynamic(Guid? elementId, dynamic value, string displayTimeZone)
+    {
+        dynamic element = new ExpandoObject();
+        element.element = GetElement(elementId.Value.ToString("d"));
+        element.value = value;
+        element.display_timezone = displayTimeZone;
 
         return element;
     }

--- a/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariant.json
+++ b/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariant.json
@@ -58,7 +58,8 @@
       "element": {
         "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
       },
-      "value": "2017-07-04T00:00:00Z"
+      "value": "2017-07-04T00:00:00Z",
+      "display_timezone": null
     },
     {
       "element": {

--- a/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariants.json
+++ b/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariants.json
@@ -59,7 +59,8 @@
         "element": {
           "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
         },
-        "value": "2017-07-04T00:00:00Z"
+        "value": "2017-07-04T00:00:00Z",
+        "display_timezone": null
       },
       {
         "element": {
@@ -235,7 +236,8 @@
         "element": {
           "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
         },
-        "value": "2017-07-04T00:00:00Z"
+        "value": "2017-07-04T00:00:00Z",
+        "display_timezone": null
       },
       {
         "element": {

--- a/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage1.json
+++ b/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage1.json
@@ -60,7 +60,8 @@
           "element": {
             "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
           },
-          "value": "2017-07-04T00:00:00Z"
+          "value": "2017-07-04T00:00:00Z",
+          "display_timezone": null
         },
         {
           "element": {
@@ -236,7 +237,8 @@
           "element": {
             "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
           },
-          "value": "2017-07-04T00:00:00Z"
+          "value": "2017-07-04T00:00:00Z",
+          "display_timezone": null
         },
         {
           "element": {

--- a/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage2.json
+++ b/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage2.json
@@ -60,7 +60,8 @@
           "element": {
             "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
           },
-          "value": "2017-07-04T00:00:00Z"
+          "value": "2017-07-04T00:00:00Z",
+          "display_timezone": null
         },
         {
           "element": {
@@ -236,7 +237,8 @@
           "element": {
             "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
           },
-          "value": "2017-07-04T00:00:00Z"
+          "value": "2017-07-04T00:00:00Z",
+          "display_timezone": null
         },
         {
           "element": {

--- a/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage3.json
+++ b/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage3.json
@@ -60,7 +60,8 @@
           "element": {
             "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
           },
-          "value": "2017-07-04T00:00:00Z"
+          "value": "2017-07-04T00:00:00Z",
+          "display_timezone": null
         },
         {
           "element": {
@@ -236,7 +237,8 @@
           "element": {
             "id": "0827e079-3754-5a1d-9381-8ff695a5bbf7"
           },
-          "value": "2017-07-04T00:00:00Z"
+          "value": "2017-07-04T00:00:00Z",
+          "display_timezone": null
         },
         {
           "element": {

--- a/Kontent.Ai.Management.Tests/Modules/ModelBuilders/ElementModelProviderTests.cs
+++ b/Kontent.Ai.Management.Tests/Modules/ModelBuilders/ElementModelProviderTests.cs
@@ -10,6 +10,7 @@ using Kontent.Ai.Management.Models.Shared;
 using Kontent.Ai.Management.Models.LanguageVariants;
 using Kontent.Ai.Management.Modules.Extensions;
 using Kontent.Ai.Management.Models.LanguageVariants.Elements;
+using FluentAssertions;
 
 namespace Kontent.Ai.Management.Tests.Modules.ModelBuilders;
 
@@ -32,6 +33,7 @@ public class ElementModelProviderTests
         Assert.Equal(expected.Title.Value, actual.Title.Value);
         Assert.Equal(expected.Rating.Value, actual.Rating.Value);
         Assert.Equal(expected.PostDate.Value, actual.PostDate.Value);
+        Assert.Equal(expected.PostDate.DisplayTimeZone, actual.PostDate.DisplayTimeZone);
         Assert.Equal(expected.UrlPattern.Mode, actual.UrlPattern.Mode);
         Assert.Equal(expected.UrlPattern.Value, actual.UrlPattern.Value);
         Assert.Equal(expected.BodyCopy.Value, actual.BodyCopy.Value);
@@ -70,9 +72,9 @@ public class ElementModelProviderTests
                 elementObject.element.id == type.GetProperty(nameof(model.SelectedForm))?.GetKontentElementId()
         );
 
-        var postDateValue = dynamicElements.SingleOrDefault(elementObject =>
+        var postDateElement = dynamicElements.SingleOrDefault(elementObject =>
              elementObject.element.id == type.GetProperty(nameof(model.PostDate))?.GetKontentElementId()
-        ).value;
+        );
 
         var urlPatternElement = dynamicElements.SingleOrDefault(elementObject =>
              elementObject.element.id == type.GetProperty(nameof(model.UrlPattern))?.GetKontentElementId()
@@ -102,7 +104,8 @@ public class ElementModelProviderTests
         Assert.Equal(model.Rating.Value, ratingValue);
         Assert.Equal(model.SelectedForm.Value, selectedForm.value);
         Assert.Equal(model.SelectedForm.SearchableValue, selectedForm.searchable_value);
-        Assert.Equal(model.PostDate.Value, postDateValue);
+        Assert.Equal(model.PostDate.Value, postDateElement.value);
+        Assert.Equal(model.PostDate.DisplayTimeZone, postDateElement.display_timezone);
         Assert.Equal(model.UrlPattern.Value, urlPatternElement.value);
         Assert.Equal(model.UrlPattern.Mode, urlPatternElement.mode);
         Assert.Equal(model.BodyCopy.Value, bodyCopyElement.value);
@@ -128,7 +131,7 @@ public class ElementModelProviderTests
                 SearchableValue = "Almighty form!",
 
             },
-            PostDate = new DateTimeElement() { Value = new DateTime(2017, 7, 4) },
+            PostDate = new DateTimeElement() { Value = new DateTime(2017, 7, 4), DisplayTimeZone = "Australia/Sydney" },
             UrlPattern = new UrlSlugElement { Value = "urlslug", Mode = "custom" },
             BodyCopy = new RichTextElement
             {
@@ -185,7 +188,8 @@ public class ElementModelProviderTests
             new
             {
                 element = new { id = type.GetProperty(nameof(ComplexTestModel.PostDate))?.GetKontentElementId() },
-                value = model.PostDate.Value
+                value = model.PostDate.Value,
+                display_timezone = model.PostDate.DisplayTimeZone
             },
             new
             {

--- a/Kontent.Ai.Management/Models/LanguageVariants/Elements/BaseElement.cs
+++ b/Kontent.Ai.Management/Models/LanguageVariants/Elements/BaseElement.cs
@@ -99,7 +99,8 @@ public abstract class BaseElement
                 return new DateTimeElement
                 {
                     Element = Reference.FromDynamic(source.element),
-                    Value = Convert.ToDateTime(source.value)
+                    Value = Convert.ToDateTime(source.value),
+                    DisplayTimeZone = source.display_timezone?.ToString()
                 };
             }
             else if (type == typeof(LinkedItemsElement))

--- a/Kontent.Ai.Management/Models/LanguageVariants/Elements/DateTimeElement.cs
+++ b/Kontent.Ai.Management/Models/LanguageVariants/Elements/DateTimeElement.cs
@@ -15,10 +15,17 @@ public class DateTimeElement : BaseElement
     public DateTime Value { get; set; }
 
     /// <summary>
+    /// IANA time zone name used to display time offset of datetime element in the UI.
+    /// </summary>
+    [JsonProperty("display_timezone")]
+    public string DisplayTimeZone { get; set; }
+
+    /// <summary>
     /// Coverts the datetime element to the dynamic object.
     /// </summary>
     public override dynamic ToDynamic() => new {
         element = Element.ToDynamic(),
         value = Value,
+        display_timezone = DisplayTimeZone
     };
 }

--- a/Kontent.Ai.Management/Models/Workflow/ScheduleModel.cs
+++ b/Kontent.Ai.Management/Models/Workflow/ScheduleModel.cs
@@ -14,4 +14,10 @@ public class ScheduleModel
     /// </summary>
     [JsonProperty("scheduled_to")]
     public DateTimeOffset ScheduleTo { get; set; }
+
+    /// <summary>
+    /// IANA time zone name used to display time offset of the scheduled publish date in the UI.
+    /// </summary>
+    [JsonProperty("display_timezone")]
+    public string DisplayTimeZone { get; set; }
 }


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #KCL-9004`

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

A new property "displayTimeZone" was added to DateTime element which affects following MAPI endpoints:
- Publish or schedule a language variant
- Unpublish or schedule unpublishing of a language variant
- Upsert a language variant

The changes needs to be reflected in the MAPI v2 docs + code samples and SDK

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?

All operations should be covered in tests.

The code samples changes merge request:
https://github.com/Kontent-ai-Learn/kontent-ai-learn-code-samples/pull/60
