### PR TITLE
KCL-9407 - add support for H5 and H6

### DIFF
--- a/Kontent.Ai.Management.Tests/Data/CodeSamples/ContentType.json
+++ b/Kontent.Ai.Management.Tests/Data/CodeSamples/ContentType.json
@@ -71,6 +71,8 @@
         "heading-two",
         "heading-three",
         "heading-four",
+        "heading-five",
+        "heading-six",
         "ordered-list",
         "unordered-list"
       ],

--- a/Kontent.Ai.Management.Tests/Data/CodeSamples/ContentTypes.json
+++ b/Kontent.Ai.Management.Tests/Data/CodeSamples/ContentTypes.json
@@ -62,6 +62,8 @@
             "heading-two",
             "heading-three",
             "heading-four",
+            "heading-five",
+            "heading-six",
             "ordered-list",
             "unordered-list"
           ],

--- a/Kontent.Ai.Management.Tests/Data/CodeSamples/PatchContentTypeResponse.json
+++ b/Kontent.Ai.Management.Tests/Data/CodeSamples/PatchContentTypeResponse.json
@@ -60,6 +60,8 @@
         "heading-two",
         "heading-three",
         "heading-four",
+        "heading-five",
+        "heading-six",
         "ordered-list",
         "unordered-list"
       ],

--- a/Kontent.Ai.Management/Models/Types/Elements/RichTextTextBlockType.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/RichTextTextBlockType.cs
@@ -47,5 +47,17 @@ public enum RichTextTextBlockType
     /// HeadingFour
     /// </summary>
     [EnumMember(Value = "heading-four")]
-    HeadingFour
+    HeadingFour,
+    
+    /// <summary>
+    /// HeadingFive
+    /// </summary>
+    [EnumMember(Value = "heading-five")]
+    HeadingFive,
+    
+    /// <summary>
+    /// HeadingSix
+    /// </summary>
+    [EnumMember(Value = "heading-six")]
+    HeadingSix
 }


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #`KCL-9407`

We have added support for H5 and H6 in MAPI for rich text element.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Modify RT element in CT. Set some limitations.

- Check, that H5 and H6 are present in `RichTextElementMetadataModel.AllowedTextBlocks`
- If CT contains rte with some limitations and H5/H6 are allowed, it is possible to read this CT via `GetContentTypeAsync` method. 
