### PR TITLE
KCL-9904 Remove is_non_localizable property from unsupported type elements in MAPI

### DIFF
--- a/Kontent.Ai.Management.Tests/Data/ContentType/ContentType.json
+++ b/Kontent.Ai.Management.Tests/Data/ContentType/ContentType.json
@@ -11,8 +11,7 @@
       "type": "guidelines",
       "external_id": "2a3a744e-0529-dd13-793c-9e668133d48b",
       "id": "f9f65756-5ed8-55ed-9d2a-43f9fe7974cd",
-      "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b",
-      "is_non_localizable": false
+      "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b"
     },
     {
       "maximum_text_length": null,

--- a/Kontent.Ai.Management.Tests/Data/ContentType/ContentTypesPage2.json
+++ b/Kontent.Ai.Management.Tests/Data/ContentType/ContentTypesPage2.json
@@ -13,8 +13,7 @@
           "type": "guidelines",
           "external_id": "14cba67c-fc38-63f9-93c7-c29c03c20292",
           "id": "55bd6dec-5390-5b65-91fa-a1532cb8153a",
-          "codename": "n14cba67c_fc38_63f9_93c7_c29c03c20292",
-          "is_non_localizable": false
+          "codename": "n14cba67c_fc38_63f9_93c7_c29c03c20292"
         },
         {
           "maximum_text_length": null,
@@ -153,8 +152,7 @@
           "type": "snippet",
           "external_id": "75c6b7ad-eabf-e936-2843-bd31f0cfff1d",
           "id": "15305a25-375f-58c9-8136-892648686cdf",
-          "codename": "metadata",
-          "is_non_localizable": false
+          "codename": "metadata"
         }
       ]
     },
@@ -171,8 +169,7 @@
           "type": "guidelines",
           "external_id": "327e98b0-f269-c0e5-230a-46b7d0be0f45",
           "id": "6d73a092-aace-57d3-a8ea-676421fea646",
-          "codename": "n327e98b0_f269_c0e5_230a_46b7d0be0f45",
-          "is_non_localizable": false
+          "codename": "n327e98b0_f269_c0e5_230a_46b7d0be0f45"
         },
         {
           "maximum_text_length": null,

--- a/Kontent.Ai.Management.Tests/Data/ContentTypeSnippet/Snippet.json
+++ b/Kontent.Ai.Management.Tests/Data/ContentTypeSnippet/Snippet.json
@@ -10,8 +10,7 @@
       "type": "guidelines",
       "external_id": "2a3a744e-0529-dd13-793c-9e668133d48b",
       "id": "f9f65756-5ed8-55ed-9d2a-43f9fe7974cd",
-      "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b",
-      "is_non_localizable": false
+      "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b"
     },
     {
       "maximum_text_length": null,

--- a/Kontent.Ai.Management.Tests/Data/ContentTypeSnippet/SnippetsPage1.json
+++ b/Kontent.Ai.Management.Tests/Data/ContentTypeSnippet/SnippetsPage1.json
@@ -12,8 +12,7 @@
           "type": "guidelines",
           "external_id": "2a3a744e-0529-dd13-793c-9e668133d48b",
           "id": "f9f65756-5ed8-55ed-9d2a-43f9fe7974cd",
-          "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b",
-          "is_non_localizable": false
+          "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b"
         },
         {
           "maximum_text_length": null,

--- a/Kontent.Ai.Management.Tests/Data/ContentTypeSnippet/SnippetsPage2.json
+++ b/Kontent.Ai.Management.Tests/Data/ContentTypeSnippet/SnippetsPage2.json
@@ -12,8 +12,7 @@
           "type": "guidelines",
           "external_id": "2a3a744e-0529-dd13-793c-9e668133d48b",
           "id": "f9f65756-5ed8-55ed-9d2a-43f9fe7974cd",
-          "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b",
-          "is_non_localizable": false
+          "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b"
         },
         {
           "maximum_text_length": null,
@@ -192,8 +191,7 @@
           "type": "guidelines",
           "external_id": "2a3a744e-0529-dd13-793c-9e668133d48b",
           "id": "f9f65756-5ed8-55ed-9d2a-43f9fe7974cd",
-          "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b",
-          "is_non_localizable": false
+          "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b"
         },
         {
           "maximum_text_length": null,

--- a/Kontent.Ai.Management.Tests/Data/ContentTypeSnippet/SnippetsPage3.json
+++ b/Kontent.Ai.Management.Tests/Data/ContentTypeSnippet/SnippetsPage3.json
@@ -12,8 +12,7 @@
           "type": "guidelines",
           "external_id": "2a3a744e-0529-dd13-793c-9e668133d48b",
           "id": "f9f65756-5ed8-55ed-9d2a-43f9fe7974cd",
-          "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b",
-          "is_non_localizable": false
+          "codename": "n2a3a744e_0529_dd13_793c_9e668133d48b"
         },
         {
           "maximum_text_length": null,

--- a/Kontent.Ai.Management/Models/Types/Elements/AssetElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/AssetElementMetadataModel.cs
@@ -21,6 +21,12 @@ public class AssetElementMetadataModel : ElementMetadataBase
     public bool IsRequired { get; set; }
 
     /// <summary>
+    /// Gets or sets element is non-localizable
+    /// </summary>
+    [JsonProperty("is_non_localizable")]
+    public bool IsNonLocalizable { get; set; }
+
+    /// <summary>
     /// Gets or sets the element's guidelines.
     /// Guidelines are used to providing instructions on what to fill in.
     /// </summary>

--- a/Kontent.Ai.Management/Models/Types/Elements/CustomElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/CustomElementMetadataModel.cs
@@ -22,6 +22,12 @@ public class CustomElementMetadataModel : ElementMetadataBase
     public bool IsRequired { get; set; }
 
     /// <summary>
+    /// Gets or sets element is non-localizable
+    /// </summary>
+    [JsonProperty("is_non_localizable")]
+    public bool IsNonLocalizable { get; set; }
+
+    /// <summary>
     /// Gets or sets the element's guidelines, providing instructions on what to fill in.
     /// </summary>
     [JsonProperty("guidelines")]

--- a/Kontent.Ai.Management/Models/Types/Elements/DateTimeElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/DateTimeElementMetadataModel.cs
@@ -21,6 +21,12 @@ public class DateTimeElementMetadataModel : ElementMetadataBase
     public bool IsRequired { get; set; }
 
     /// <summary>
+    /// Gets or sets element is non-localizable
+    /// </summary>
+    [JsonProperty("is_non_localizable")]
+    public bool IsNonLocalizable { get; set; }
+
+    /// <summary>
     /// Gets or sets the element's guidelines, providing instructions on what to fill in.
     /// </summary>
     [JsonProperty("guidelines")]

--- a/Kontent.Ai.Management/Models/Types/Elements/ElementMetadataBase.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/ElementMetadataBase.cs
@@ -41,10 +41,4 @@ public abstract class ElementMetadataBase
     /// </summary>
     [JsonProperty("content_group", DefaultValueHandling = DefaultValueHandling.Ignore)]
     public Reference ContentGroup { get; set; }
-
-    /// <summary>
-    /// Gets or sets element is non-localizable
-    /// </summary>
-    [JsonProperty("is_non_localizable")]
-    public bool IsNonLocalizable { get; set; }
 }

--- a/Kontent.Ai.Management/Models/Types/Elements/LinkedItemsElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/LinkedItemsElementMetadataModel.cs
@@ -23,6 +23,12 @@ public class LinkedItemsElementMetadataModel : ElementMetadataBase
     public bool IsRequired { get; set; }
 
     /// <summary>
+    /// Gets or sets element is non-localizable
+    /// </summary>
+    [JsonProperty("is_non_localizable")]
+    public bool IsNonLocalizable { get; set; }
+
+    /// <summary>
     /// Gets or sets the element's guidelines, providing instructions on what to fill in.
     /// </summary>
     [JsonProperty("guidelines")]

--- a/Kontent.Ai.Management/Models/Types/Elements/MultipleChoiceElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/MultipleChoiceElementMetadataModel.cs
@@ -22,6 +22,12 @@ public class MultipleChoiceElementMetadataModel : ElementMetadataBase
     public bool IsRequired { get; set; }
 
     /// <summary>
+    /// Gets or sets element is non-localizable
+    /// </summary>
+    [JsonProperty("is_non_localizable")]
+    public bool IsNonLocalizable { get; set; }
+
+    /// <summary>
     /// Gets or sets the element's guidelines, providing instructions on what to fill in.
     /// </summary>
     [JsonProperty("guidelines")]

--- a/Kontent.Ai.Management/Models/Types/Elements/NumberElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/NumberElementMetadataModel.cs
@@ -21,6 +21,12 @@ public class NumberElementMetadataModel : ElementMetadataBase
     public bool IsRequired { get; set; }
 
     /// <summary>
+    /// Gets or sets element is non-localizable
+    /// </summary>
+    [JsonProperty("is_non_localizable")]
+    public bool IsNonLocalizable { get; set; }
+
+    /// <summary>
     /// Gets or sets the element's guidelines, providing instructions on what to fill in.
     /// </summary>
     [JsonProperty("guidelines")]

--- a/Kontent.Ai.Management/Models/Types/Elements/RichTextElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/RichTextElementMetadataModel.cs
@@ -22,6 +22,12 @@ public class RichTextElementMetadataModel : ElementMetadataBase
     public bool IsRequired { get; set; }
 
     /// <summary>
+    /// Gets or sets element is non-localizable
+    /// </summary>
+    [JsonProperty("is_non_localizable")]
+    public bool IsNonLocalizable { get; set; }
+
+    /// <summary>
     /// Gets or sets the element's guidelines, providing instructions on what to fill in.
     /// </summary>
     [JsonProperty("guidelines")]

--- a/Kontent.Ai.Management/Models/Types/Elements/SubpagesElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/SubpagesElementMetadataModel.cs
@@ -22,6 +22,12 @@ public class SubpagesElementMetadataModel : ElementMetadataBase
     public bool IsRequired { get; set; }
 
     /// <summary>
+    /// Gets or sets element is non-localizable
+    /// </summary>
+    [JsonProperty("is_non_localizable")]
+    public bool IsNonLocalizable { get; set; }
+
+    /// <summary>
     /// Gets or sets the element's guidelines, providing instructions on what to fill in.
     /// </summary>
     [JsonProperty("guidelines")]

--- a/Kontent.Ai.Management/Models/Types/Elements/TaxonomyElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/TaxonomyElementMetadataModel.cs
@@ -16,6 +16,12 @@ public class TaxonomyElementMetadataModel : ElementMetadataBase
     public bool IsRequired { get; set; }
 
     /// <summary>
+    /// Gets or sets element is non-localizable
+    /// </summary>
+    [JsonProperty("is_non_localizable")]
+    public bool IsNonLocalizable { get; set; }
+
+    /// <summary>
     /// Gets or sets the element's guidelines, providing instructions on what to fill in.
     /// </summary>
     [JsonProperty("guidelines")]

--- a/Kontent.Ai.Management/Models/Types/Elements/TextElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/TextElementMetadataModel.cs
@@ -21,6 +21,12 @@ public class TextElementMetadataModel : ElementMetadataBase
     public bool IsRequired { get; set; }
 
     /// <summary>
+    /// Gets or sets element is non-localizable
+    /// </summary>
+    [JsonProperty("is_non_localizable")]
+    public bool IsNonLocalizable { get; set; }
+
+    /// <summary>
     /// Gets or sets the element's guidelines, providing instructions on what to fill in.
     /// </summary>
     [JsonProperty("guidelines")]

--- a/Kontent.Ai.Management/Models/Types/Elements/UrlSlugElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/UrlSlugElementMetadataModel.cs
@@ -20,6 +20,12 @@ public class UrlSlugElementMetadataModel : ElementMetadataBase
     public bool IsRequired { get; set; }
 
     /// <summary>
+    /// Gets or sets element is non-localizable
+    /// </summary>
+    [JsonProperty("is_non_localizable")]
+    public bool IsNonLocalizable { get; set; }
+
+    /// <summary>
     /// Gets or sets the element's guidelines, providing instructions on what to fill in.
     /// </summary>
     [JsonProperty("guidelines")]


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #`KCL-9904`

We decided to remove `IsNonLocalizable` property from all type elements which are not supported and will not be supported in the future before we release this feature publicly in December (currently this feature is in early access). The type elements that should not have this property are snippet element and guidelines element.

After discussion with @Simply007 we decided that this can be released as a new minor version because non-localizable elements are still in early access. But we can discuss it further if you think it should be considered a breaking change and released as a new major version.

### Checklist

- [X] Code follows coding conventions held in this repo
- [X] Automated tests have been added
- [X] Tests are passing
- [X] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
