### PR TITLE
fix retry policy

### DIFF
--- a/Kontent.Ai.Management/Exceptions/ManagementException.cs
+++ b/Kontent.Ai.Management/Exceptions/ManagementException.cs
@@ -14,7 +14,7 @@ public sealed class ManagementException : Exception
     /// <summary>
     /// Gets the HTTP status code of the response.
     /// </summary>
-    public HttpStatusCode StatusCode { get; }
+    public HttpStatusCode? StatusCode { get; }
 
     /// <summary>
     /// Gets the error message from the response.

--- a/Kontent.Ai.Management/Kontent.Ai.Management.csproj
+++ b/Kontent.Ai.Management/Kontent.Ai.Management.csproj
@@ -30,8 +30,9 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="Microsoft.Sourcelink.Github" Version="1.1.1" PrivateAssets="All" />
 		<PackageReference Include="Polly" Version="7.2.3" />
-		<None Include="../README.md" Pack="true" PackagePath=""/>
-		<None Include="../kai-logo-symbol-color-rgb.png" Pack="true" PackagePath=""/>
+		<PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
+		<None Include="../README.md" Pack="true" PackagePath="" />
+		<None Include="../kai-logo-symbol-color-rgb.png" Pack="true" PackagePath="" />
 	</ItemGroup>
 
 </Project>

--- a/Kontent.Ai.Management/Modules/HttpClient/ManagementHttpClient.cs
+++ b/Kontent.Ai.Management/Modules/HttpClient/ManagementHttpClient.cs
@@ -59,15 +59,8 @@ internal class ManagementHttpClient : IManagementHttpClient
             }
 
             // Use the resilience logic.
-            try
-            {
-                response = await _resiliencePolicyProvider.Policy.ExecuteAsync(() =>
-                    SendHttpMessage(messageCreator, endpointUrl, method, requestContent, headers));
-            }
-            catch(Exception)
-            {
-                throw;
-            }
+            response = await _resiliencePolicyProvider.Policy.ExecuteAsync(() =>
+                SendHttpMessage(messageCreator, endpointUrl, method, requestContent, headers));
         }
         else
         {

--- a/Kontent.Ai.Management/Modules/HttpClient/ManagementHttpClient.cs
+++ b/Kontent.Ai.Management/Modules/HttpClient/ManagementHttpClient.cs
@@ -59,10 +59,15 @@ internal class ManagementHttpClient : IManagementHttpClient
             }
 
             // Use the resilience logic.
-            var policyResult = await _resiliencePolicyProvider.Policy.ExecuteAndCaptureAsync(() =>
-                SendHttpMessage(messageCreator, endpointUrl, method, requestContent, headers));
-
-            response = policyResult.FinalHandledResult ?? policyResult.Result;
+            try
+            {
+                response = await _resiliencePolicyProvider.Policy.ExecuteAsync(() =>
+                    SendHttpMessage(messageCreator, endpointUrl, method, requestContent, headers));
+            }
+            catch(Exception)
+            {
+                throw;
+            }
         }
         else
         {


### PR DESCRIPTION
### Motivation

 Fixes #211 
Improve overall default retry policy. It only worked for responses from MAPI, but it did not take into account that an exception can be thrown. 

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Unit tests added.
