### PR TITLE
Add custom headers to webhooks

### DIFF
--- a/Kontent.Ai.Management.Tests/CodeSamples/CmApiV2.cs
+++ b/Kontent.Ai.Management.Tests/CodeSamples/CmApiV2.cs
@@ -1411,6 +1411,19 @@ public class CmApiV2 : IClassFixture<FileSystemFixture>
             Name = "Example webhook",
             Url = "https://example.com/webhook",
             Secret = "secret_key",
+            Headers = new []
+            {
+                new CustomHeaderModel
+                {
+                    Key = "key1",
+                    Value = "value1"
+                },
+                new CustomHeaderModel
+                {
+                    Key = "key2",
+                    Value = "value2"
+                }
+            },
             DeliveryTriggers = new DeliveryTriggersModel
             {
                 ContentType = new ContentTypeTriggerModel

--- a/Kontent.Ai.Management.Tests/Data/CodeSamples/PostWebhookResponse.json
+++ b/Kontent.Ai.Management.Tests/Data/CodeSamples/PostWebhookResponse.json
@@ -3,6 +3,16 @@
   "name": "Example webhook",
   "url": "https://example.com/webhook",
   "secret": "secret_key",
+  "headers": [
+    {
+      "key": "key1",
+      "value": "value1"
+    },
+    {
+      "key": "key2",
+      "value": "value2"
+    }
+  ],
   "enabled": true,
   "last_modified": "2023-12-13T11:22:34.4079256Z",
   "delivery_triggers": {

--- a/Kontent.Ai.Management.Tests/Data/CodeSamples/Webhook.json
+++ b/Kontent.Ai.Management.Tests/Data/CodeSamples/Webhook.json
@@ -3,6 +3,12 @@
   "name": "Example webhook",
   "url": "https://example.com/webhook",
   "secret": "secret_key",
+  "headers": [
+    {
+      "key": "key1",
+      "value": "value1"
+    }
+  ],
   "enabled": true,
   "last_modified": "2023-12-13T11:22:34.4079256Z",
   "delivery_triggers": {

--- a/Kontent.Ai.Management.Tests/Data/CodeSamples/Webhooks.json
+++ b/Kontent.Ai.Management.Tests/Data/CodeSamples/Webhooks.json
@@ -4,6 +4,7 @@
     "name": "Example webhook",
     "url": "https://example.com/webhook",
     "secret": "secret_key",
+    "headers": [],
     "enabled": true,
     "last_modified": "2023-12-13T11:22:34.4079256Z",
     "delivery_triggers": {

--- a/Kontent.Ai.Management.Tests/Data/Webhook/Webhook.json
+++ b/Kontent.Ai.Management.Tests/Data/Webhook/Webhook.json
@@ -3,6 +3,12 @@
   "name": "Webhook_all_triggers",
   "url": "http://test",
   "secret": "AQA1jsNDjLBUcRRD69GQtuzBBqxGPdz+0XhTKhICv4o=",
+  "headers": [
+    {
+      "key": "key1",
+      "value": "value1"
+    }
+  ],
   "enabled": true,
   "last_modified": "2023-12-13T11:22:34.4079256Z",
   "delivery_triggers": {

--- a/Kontent.Ai.Management.Tests/Data/Webhook/Webhooks.json
+++ b/Kontent.Ai.Management.Tests/Data/Webhook/Webhooks.json
@@ -4,6 +4,12 @@
     "name": "webhooks_all_triggers",
     "url": "http://test",
     "secret": "AQA1jsNDjLBUcRRD69GQtuzBBqxGPdz+0XhTKhICv4o=",
+    "headers": [
+      {
+        "key": "key1",
+        "value": "value1"
+      }      
+    ],
     "enabled": true,
     "last_modified": "2023-12-13T11:22:34.4079256Z",
     "delivery_triggers": {
@@ -115,6 +121,7 @@
     "name": "second_webhook",
     "url": "http://test",
     "secret": "Ye7/QP5fyP+pjCD5rQeKkqUBeVfFus3EULWPPY0OaKI=",
+    "headers": [],
     "enabled": true,
     "last_modified": "2023-12-13T11:31:11.1874628Z",
     "delivery_triggers": {

--- a/Kontent.Ai.Management.Tests/ManagementClientTests/WebhookTests.cs
+++ b/Kontent.Ai.Management.Tests/ManagementClientTests/WebhookTests.cs
@@ -90,6 +90,14 @@ public class WebhookTests : IClassFixture<FileSystemFixture>
             Enabled = true,
             Name = "name",
             Secret = "password",
+            Headers = new []
+            {
+                new CustomHeaderModel
+                {
+                    Key = "key1",
+                    Value = "value1"
+                }
+            },
             Url = "url",
             DeliveryTriggers = new DeliveryTriggersModel {
                 ContentType = new ContentTypeTriggerModel {

--- a/Kontent.Ai.Management/Models/Webhooks/CustomHeaderModel.cs
+++ b/Kontent.Ai.Management/Models/Webhooks/CustomHeaderModel.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+
+namespace Kontent.Ai.Management.Models.Webhooks;
+
+/// <summary>
+/// Represents webhook custom HTTP headers. Custom headers are sent together with existing headers.
+/// </summary>
+public class CustomHeaderModel
+{
+    /// <summary>
+    /// The custom header key defines the name of the HTTP header.
+    /// More info: https://kontent.ai/learn/docs/apis/openapi/management-api-v2/#section/Webhook-object
+    /// </summary>
+    [JsonProperty("key")]
+    public string Key { get; set; }
+    
+    /// <summary>
+    /// The custom header value.
+    /// More info: https://kontent.ai/learn/docs/apis/openapi/management-api-v2/#section/Webhook-object
+    /// </summary>
+    [JsonProperty("value")]
+    public string Value { get; set; }
+}

--- a/Kontent.Ai.Management/Models/Webhooks/CustomHeaderModel.cs
+++ b/Kontent.Ai.Management/Models/Webhooks/CustomHeaderModel.cs
@@ -3,7 +3,7 @@
 namespace Kontent.Ai.Management.Models.Webhooks;
 
 /// <summary>
-/// Represents webhook custom HTTP headers. Custom headers are sent together with existing headers.
+/// Represents a custom HTTP header of a webhook. Custom headers are sent together with existing headers.
 /// </summary>
 public class CustomHeaderModel
 {

--- a/Kontent.Ai.Management/Models/Webhooks/WebhookCreateModel.cs
+++ b/Kontent.Ai.Management/Models/Webhooks/WebhookCreateModel.cs
@@ -1,5 +1,6 @@
 ﻿using Kontent.Ai.Management.Models.Webhooks.Triggers;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Kontent.Ai.Management.Models.Webhooks;
 
@@ -25,6 +26,12 @@ public class WebhookCreateModel
     /// </summary>
     [JsonProperty("secret")]
     public string Secret { get; set; }
+    
+    /// <summary>
+    /// Gets or sets webhook's custom HTTP headers, used to send extra information in webhook notifications.
+    /// </summary>
+    [JsonProperty("headers")]
+    public IEnumerable<CustomHeaderModel> Headers { get; set; }
     
     /// <summary>
     /// Determines if the webhook is enabled. By default, the enabled property is set to true.

--- a/Kontent.Ai.Management/Models/Webhooks/WebhookModel.cs
+++ b/Kontent.Ai.Management/Models/Webhooks/WebhookModel.cs
@@ -1,6 +1,7 @@
 ﻿using Kontent.Ai.Management.Models.Webhooks.Triggers;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 
 namespace Kontent.Ai.Management.Models.Webhooks;
 
@@ -32,6 +33,12 @@ public class WebhookModel
     /// </summary>
     [JsonProperty("secret")]
     public string Secret { get; set; }
+    
+    /// <summary>
+    /// Gets or sets webhook's custom HTTP headers, used to send extra information in webhook notifications.
+    /// </summary>
+    [JsonProperty("headers")]
+    public IEnumerable<CustomHeaderModel> Headers { get; set; }
     
     /// <summary>
     /// Determines if the webhook is enabled. By default, the enabled property is set to true.


### PR DESCRIPTION
### Motivation

Enable customers to enhance webhook notifications with custom headers. Do not release before Feb 21, 2024.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
