### PR TITLE
Add move operation to type, snippet and taxonomy PATCH

### DIFF
--- a/Kontent.Ai.Management.Tests/CodeSamples/CmApiV2.cs
+++ b/Kontent.Ai.Management.Tests/CodeSamples/CmApiV2.cs
@@ -846,6 +846,16 @@ public class CmApiV2 : IClassFixture<FileSystemFixture>
             new ContentTypeSnippetPatchRemoveModel
             {
                 Path = "/elements/external_id:my-multiple-choice-id/options/codename:my_option"
+            },
+            new ContentTypeSnippetPatchMoveModel
+            {
+                Path = "/elements/codename:my_metadata_snippet__my_meta_title",
+                After = Reference.ByCodename("my_metadata_snippet__my_meta_description")
+            },
+            new ContentTypeSnippetPatchMoveModel
+            {
+                Path = "/elements/external_id:my-multiple-choice-id/options/id:8e6ec8b1-6510-4b9b-b4be-6c977f4bdfbc",
+                Before = Reference.ById(Guid.Parse("6bfe5a60-5cc2-4303-8f72-9cc53431046b"))
             }
         });
 
@@ -908,6 +918,11 @@ public class CmApiV2 : IClassFixture<FileSystemFixture>
                     ExternalId = "my-new-term",
                     Terms = Array.Empty<TaxonomyTermCreateModel>()
                 }
+            },
+            new TaxonomyGroupMovePatchModel
+            {
+                Reference = Reference.ByExternalId("my-new-term"),
+                Before = Reference.ByCodename("first_term")
             }
         });
 
@@ -959,6 +974,16 @@ public class CmApiV2 : IClassFixture<FileSystemFixture>
             new ContentTypeRemovePatchModel
             {
                 Path = "/elements/id:0b2015d0-16ae-414a-85f9-7e1a4b3a3eae"
+            },
+            new ContentTypeMovePatchModel
+            {
+                Path = "/elements/codename:my_text_element",
+                After = Reference.ByExternalId("my-title-id")
+            },
+            new ContentTypeMovePatchModel
+            {
+                Path = "/elements/external_id:my-multiple-choice-id/options/id:d66ffa49-86ff-eeaa-c33b-e5d9eefe8b81",
+                Before = Reference.ById(Guid.Parse("523e6231-8d80-a158-3601-dffde4e64a78"))
             }
         });
 

--- a/Kontent.Ai.Management.Tests/ManagementClientTests/ContentTypeSnippetTests.cs
+++ b/Kontent.Ai.Management.Tests/ManagementClientTests/ContentTypeSnippetTests.cs
@@ -304,6 +304,10 @@ public class ContentTypeSnippetTests
             },
             After = Reference.ByCodename("personas"),
             Path = "/elements"
+        },
+        new ContentTypeSnippetPatchMoveModel {
+            Path = "/elements/codename:summary",
+            After = Reference.ByCodename("personas")
         }
     };
 

--- a/Kontent.Ai.Management.Tests/ManagementClientTests/ContentTypeTests.cs
+++ b/Kontent.Ai.Management.Tests/ManagementClientTests/ContentTypeTests.cs
@@ -303,6 +303,10 @@ public class ContentTypeTests
                 },
                 Before = Reference.ByCodename("theme"),
                 Path = "/elements"
+            },
+            new ContentTypeMovePatchModel {
+                Path = "/elements/codename:display_options",
+                After = Reference.ByCodename("theme")
             }
         };
 }

--- a/Kontent.Ai.Management.Tests/ManagementClientTests/TaxonomyGroupTests.cs
+++ b/Kontent.Ai.Management.Tests/ManagementClientTests/TaxonomyGroupTests.cs
@@ -296,6 +296,10 @@ public class TaxonomyGroupTests
                 ExternalId = "b378225f-6dfc-e261-3848-dd030a6d7883",
                 Terms = Array.Empty<TaxonomyTermCreateModel>()
             }
+        },
+        new TaxonomyGroupMovePatchModel {
+            Reference = Reference.ByCodename("chemex"),
+            Under = Reference.ByCodename("hario")
         }
     };
 }

--- a/Kontent.Ai.Management/Models/AssetFolders/Patch/AssetFolderAddIntoModel.cs
+++ b/Kontent.Ai.Management/Models/AssetFolders/Patch/AssetFolderAddIntoModel.cs
@@ -27,7 +27,7 @@ public class AssetFolderAddIntoModel : AssetFolderOperationBaseModel
     public Reference Before { get; set; }
 
     /// <summary>
-    /// Gets or sets reference of the existing folder before which you want to add the new folder.
+    /// Gets or sets reference of the existing folder after which you want to add the new folder.
     /// Note: The before and after properties are mutually exclusive.
     /// </summary>
     [JsonProperty("after")]

--- a/Kontent.Ai.Management/Models/TaxonomyGroups/Patch/TaxonomyGroupAddIntoPatchModel.cs
+++ b/Kontent.Ai.Management/Models/TaxonomyGroups/Patch/TaxonomyGroupAddIntoPatchModel.cs
@@ -28,7 +28,7 @@ public class TaxonomyGroupAddIntoPatchModel : TaxonomyGroupOperationBaseModel
     public Reference Before { get; set; }
 
     /// <summary>
-    /// Gets or sets reference of the existing taxonomy term before which you want to add the new taxonomy term.
+    /// Gets or sets reference of the existing taxonomy term after which you want to add the new taxonomy term.
     /// Note: The before and after properties are mutually exclusive.
     /// </summary>
     [JsonProperty("after")]

--- a/Kontent.Ai.Management/Models/TaxonomyGroups/Patch/TaxonomyGroupMovePatchModel.cs
+++ b/Kontent.Ai.Management/Models/TaxonomyGroups/Patch/TaxonomyGroupMovePatchModel.cs
@@ -1,0 +1,37 @@
+﻿using Kontent.Ai.Management.Models.Shared;
+using Newtonsoft.Json;
+
+namespace Kontent.Ai.Management.Models.TaxonomyGroups.Patch;
+
+/// <summary>
+/// Represents the move operation.
+/// More info: https://kontent.ai/learn/reference/management-api-v2#operation/modify-a-taxonomy-group
+/// </summary>
+public class TaxonomyGroupMovePatchModel : TaxonomyGroupOperationBaseModel
+{
+    /// <summary>
+    /// Represents the move operation.
+    /// </summary>
+    public override string Op => "move";
+
+    /// <summary>
+    /// Gets or sets reference of the existing taxonomy term before which you want to move the specified taxonomy term.
+    /// Note: The before, after and under properties are mutually exclusive.
+    /// </summary>
+    [JsonProperty("before")]
+    public Reference Before { get; set; }
+
+    /// <summary>
+    /// Gets or sets reference of the existing taxonomy term after which you want to move the specified taxonomy term.
+    /// Note: The before, after and under properties are mutually exclusive.
+    /// </summary>
+    [JsonProperty("after")]
+    public Reference After { get; set; }
+
+    /// <summary>
+    /// Gets or sets reference of the existing taxonomy term under which you want to move the specified taxonomy term.
+    /// Note: The before, after and under properties are mutually exclusive.
+    /// </summary>
+    [JsonProperty("under")]
+    public Reference Under { get; set; }
+}

--- a/Kontent.Ai.Management/Models/TypeSnippets/Patch/ContentTypeSnippetAddIntoPatchModel.cs
+++ b/Kontent.Ai.Management/Models/TypeSnippets/Patch/ContentTypeSnippetAddIntoPatchModel.cs
@@ -29,7 +29,7 @@ public class ContentTypeSnippetAddIntoPatchModel : ContentTypeSnippetOperationBa
     public Reference Before { get; set; }
 
     /// <summary>
-    /// Gets or sets reference of the existing object before which you want to add the new object.
+    /// Gets or sets reference of the existing object after which you want to add the new object.
     /// Note: The before and after properties are mutually exclusive.
     /// </summary>
     [JsonProperty("after")]

--- a/Kontent.Ai.Management/Models/TypeSnippets/Patch/ContentTypeSnippetPatchMoveModel.cs
+++ b/Kontent.Ai.Management/Models/TypeSnippets/Patch/ContentTypeSnippetPatchMoveModel.cs
@@ -1,0 +1,30 @@
+﻿using Kontent.Ai.Management.Models.Shared;
+using Newtonsoft.Json;
+
+namespace Kontent.Ai.Management.Models.TypeSnippets.Patch;
+
+/// <summary>
+/// Represents the move operation.
+/// More info: https://kontent.ai/learn/reference/management-api-v2#operation/modify-a-content-type-snippet
+/// </summary>
+public class ContentTypeSnippetPatchMoveModel : ContentTypeSnippetOperationBaseModel
+{
+    /// <summary>
+    /// Represents the move operation.
+    /// </summary>
+    public override string Op => "move";
+
+    /// <summary>
+    /// Gets or sets reference of the existing object before which you want to move the specified object.
+    /// Note: The before and after properties are mutually exclusive.
+    /// </summary>
+    [JsonProperty("before")]
+    public Reference Before { get; set; }
+
+    /// <summary>
+    /// Gets or sets reference of the existing object after which you want to move the specified object.
+    /// Note: The before and after properties are mutually exclusive.
+    /// </summary>
+    [JsonProperty("after")]
+    public Reference After { get; set; }
+}

--- a/Kontent.Ai.Management/Models/Types/Patch/ContentTypeAddIntoPatchModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Patch/ContentTypeAddIntoPatchModel.cs
@@ -29,7 +29,7 @@ public class ContentTypeAddIntoPatchModel : ContentTypeOperationBaseModel
     public Reference Before { get; set; }
 
     /// <summary>
-    /// Gets or sets reference of the existing object before which you want to add the new object.
+    /// Gets or sets reference of the existing object after which you want to add the new object.
     /// Note: The before and after properties are mutually exclusive.
     /// </summary>
     [JsonProperty("after")]

--- a/Kontent.Ai.Management/Models/Types/Patch/ContentTypeMovePatchModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Patch/ContentTypeMovePatchModel.cs
@@ -1,0 +1,30 @@
+﻿using Kontent.Ai.Management.Models.Shared;
+using Newtonsoft.Json;
+
+namespace Kontent.Ai.Management.Models.Types.Patch;
+
+/// <summary>
+/// Represents the move operation.
+/// More info: https://kontent.ai/learn/reference/management-api-v2#operation/modify-a-content-type
+/// </summary>
+public class ContentTypeMovePatchModel : ContentTypeOperationBaseModel
+{
+    /// <summary>
+    /// Represents the move operation.
+    /// </summary>
+    public override string Op => "move";
+
+    /// <summary>
+    /// Gets or sets reference of the existing object before which you want to move the specified object.
+    /// Note: The before and after properties are mutually exclusive.
+    /// </summary>
+    [JsonProperty("before")]
+    public Reference Before { get; set; }
+
+    /// <summary>
+    /// Gets or sets reference of the existing object after which you want to move the specified object.
+    /// Note: The before and after properties are mutually exclusive.
+    /// </summary>
+    [JsonProperty("after")]
+    public Reference After { get; set; }
+}


### PR DESCRIPTION
### Motivation

Add support for new move operation in content type, snippet and taxonomy PATCH endpoints.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
