### PR TITLE
EN-130 - Add schedules to content item variant

### DIFF
--- a/Kontent.Ai.Management.Tests/CodeSamples/CmApiV2.cs
+++ b/Kontent.Ai.Management.Tests/CodeSamples/CmApiV2.cs
@@ -1943,7 +1943,7 @@ public class CmApiV2 : IClassFixture<FileSystemFixture>
         // Scheduled publish
         var scheduledPublishException = await Record.ExceptionAsync(async () => await client.SchedulePublishingOfLanguageVariantAsync(identifier, new ScheduleModel
         {
-            ScheduleTo = DateTime.Parse("2038-01-19T04:14:08+01:00"),
+            ScheduleTo = DateTime.Parse("2038-01-19T04:14:08"),
             DisplayTimeZone = "Europe/London"
         }));
 
@@ -1971,7 +1971,7 @@ public class CmApiV2 : IClassFixture<FileSystemFixture>
         // Scheduled unpublish
         var scheduledUnpublishException = await Record.ExceptionAsync(async () => await client.ScheduleUnpublishingOfLanguageVariantAsync(identifier, new ScheduleModel
         {
-            ScheduleTo = DateTime.Parse("2038-01-19T04:14:08+01:00"),
+            ScheduleTo = DateTime.Parse("2038-01-19T04:14:08"),
             DisplayTimeZone = "Europe/London"
         }));
 

--- a/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariant.json
+++ b/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariant.json
@@ -159,6 +159,12 @@
       ]
     }
   ],
+  "schedule": {
+    "publish_time": "2024-03-31T08:00:00",
+    "publish_display_timezone": "Europe/Prague",
+    "unpublish_time": "2024-04-30T08:00:00",
+    "unpublish_display_timezone": "Europe/Prague"
+  },
   "workflow": {
     "workflow_identifier": {
       "id": "00000000-0000-0000-0000-000000000000"

--- a/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariants.json
+++ b/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariants.json
@@ -160,6 +160,12 @@
         ]
       }
     ],
+    "schedule": {
+      "publish_time": "2024-03-31T08:00:00",
+      "publish_display_timezone": "Europe/Prague",
+      "unpublish_time": "2024-04-30T08:00:00",
+      "unpublish_display_timezone": "Europe/Prague"
+    },
     "workflow": {
       "workflow_identifier": {
         "id": "00000000-0000-0000-0000-000000000000"
@@ -337,6 +343,12 @@
         ]
       }
     ],
+    "schedule": {
+      "publish_time": "2024-03-31T08:00:00",
+      "publish_display_timezone": "Europe/Prague",
+      "unpublish_time": "2024-04-30T08:00:00",
+      "unpublish_display_timezone": "Europe/Prague"
+    },
     "workflow": {
       "workflow_identifier": {
         "id": "00000000-0000-0000-0000-000000000000"

--- a/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage1.json
+++ b/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage1.json
@@ -161,6 +161,12 @@
           ]
         }
       ],
+      "schedule": {
+        "publish_time": "2024-03-31T08:00:00",
+        "publish_display_timezone": "Europe/Prague",
+        "unpublish_time": "2024-04-30T08:00:00",
+        "unpublish_display_timezone": "Europe/Prague"
+      },
       "workflow": {
         "workflow_identifier": {
           "id": "00000000-0000-0000-0000-000000000000"
@@ -338,6 +344,12 @@
           ]
         }
       ],
+      "schedule": {
+        "publish_time": "2024-03-31T08:00:00",
+        "publish_display_timezone": "Europe/Prague",
+        "unpublish_time": "2024-04-30T08:00:00",
+        "unpublish_display_timezone": "Europe/Prague"
+      },
       "workflow": {
         "workflow_identifier": {
           "id": "00000000-0000-0000-0000-000000000000"

--- a/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage2.json
+++ b/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage2.json
@@ -161,6 +161,12 @@
           ]
         }
       ],
+      "schedule": {
+        "publish_time": "2024-03-31T08:00:00",
+        "publish_display_timezone": "Europe/Prague",
+        "unpublish_time": "2024-04-30T08:00:00",
+        "unpublish_display_timezone": "Europe/Prague"
+      },
       "workflow": {
         "workflow_identifier": {
           "id": "00000000-0000-0000-0000-000000000000"
@@ -338,6 +344,12 @@
           ]
         }
       ],
+      "schedule": {
+        "publish_time": "2024-03-31T08:00:00",
+        "publish_display_timezone": "Europe/Prague",
+        "unpublish_time": "2024-04-30T08:00:00",
+        "unpublish_display_timezone": "Europe/Prague"
+      },
       "workflow": {
         "workflow_identifier": {
           "id": "00000000-0000-0000-0000-000000000000"

--- a/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage3.json
+++ b/Kontent.Ai.Management.Tests/Data/LanguageVariant/LanguageVariantsPage3.json
@@ -161,6 +161,12 @@
           ]
         }
       ],
+      "schedule": {
+        "publish_time": "2024-03-31T08:00:00",
+        "publish_display_timezone": "Europe/Prague",
+        "unpublish_time": "2024-04-30T08:00:00",
+        "unpublish_display_timezone": "Europe/Prague"
+      },
       "workflow": {
         "workflow_identifier": {
           "id": "00000000-0000-0000-0000-000000000000"
@@ -338,6 +344,12 @@
           ]
         }
       ],
+      "schedule": {
+        "publish_time": "2024-03-31T08:00:00",
+        "publish_display_timezone": "Europe/Prague",
+        "unpublish_time": "2024-04-30T08:00:00",
+        "unpublish_display_timezone": "Europe/Prague"
+      },
       "workflow": {
         "workflow_identifier": {
           "id": "00000000-0000-0000-0000-000000000000"

--- a/Kontent.Ai.Management.Tests/ManagementClientTests/LanguageVariantTests.cs
+++ b/Kontent.Ai.Management.Tests/ManagementClientTests/LanguageVariantTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kontent.Ai.Management.Extensions;
 using Kontent.Ai.Management.Models.LanguageVariants;
+using Kontent.Ai.Management.Models.Publishing;
 using Kontent.Ai.Management.Models.Shared;
 using Kontent.Ai.Management.Models.StronglyTyped;
 using Kontent.Ai.Management.Models.Workflow;
@@ -435,6 +436,7 @@ public class LanguageVariantTests
             Language = Reference.ById(Guid.Parse(languageId)),
             LastModified = DateTimeOffset.Parse("2021-11-06T13:57:26.7069564Z").UtcDateTime,
             Workflow = new WorkflowStepIdentifier(Reference.ById(Guid.Parse("00000000-0000-0000-0000-000000000000")), Reference.ById(Guid.Parse("eee6db3b-545a-4785-8e86-e3772c8756f9"))),
+            Schedule = GetExpectedScheduleResponseModel(),
             Elements = ElementsData.GetExpectedDynamicElements(),
         };
 
@@ -447,7 +449,16 @@ public class LanguageVariantTests
         Language = Reference.ById(Guid.Parse(languageId)),
         LastModified = DateTimeOffset.Parse("2021-11-06T13:57:26.7069564Z").UtcDateTime,
         Workflow = new WorkflowStepIdentifier(Reference.ById(Guid.Parse("00000000-0000-0000-0000-000000000000")), Reference.ById(Guid.Parse("eee6db3b-545a-4785-8e86-e3772c8756f9"))),
+        Schedule = GetExpectedScheduleResponseModel(),
         Elements = ElementsData.GetExpectedStronglyTypedElementsModel(),
+    };
+
+    private static ScheduleResponseModel GetExpectedScheduleResponseModel() => new()
+    {
+        PublishTime = DateTimeOffset.Parse("2024-03-31T08:00:00Z").UtcDateTime,
+        PublishDisplayTimeZone = "Europe/Prague",
+        UnpublishTime = DateTimeOffset.Parse("2024-04-30T08:00:00Z").UtcDateTime,
+        UnpublishDisplayTimeZone = "Europe/Prague"
     };
 
     private class CombinationOfIdentifiersAndUrl : IEnumerable<object[]>

--- a/Kontent.Ai.Management/Models/LanguageVariants/LanguageVariantModel.cs
+++ b/Kontent.Ai.Management/Models/LanguageVariants/LanguageVariantModel.cs
@@ -1,4 +1,5 @@
-﻿using Kontent.Ai.Management.Models.Shared;
+﻿using Kontent.Ai.Management.Models.Publishing;
+using Kontent.Ai.Management.Models.Shared;
 using Kontent.Ai.Management.Models.Workflow;
 using Newtonsoft.Json;
 using System;
@@ -34,6 +35,12 @@ public sealed class LanguageVariantModel
     /// </summary>
     [JsonProperty("last_modified")]
     public DateTime? LastModified { get; set; }
+
+    /// <summary>
+    /// Gets or sets the publishing and unpublishing schedule of the language variant.
+    /// </summary>
+    [JsonProperty("schedule")]
+    public ScheduleResponseModel Schedule { get; set; }
 
     /// <summary>
     /// Gets or sets workflow step identifier.

--- a/Kontent.Ai.Management/Models/Publishing/ScheduleResponseModel.cs
+++ b/Kontent.Ai.Management/Models/Publishing/ScheduleResponseModel.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Kontent.Ai.Management.Models.Publishing;
+
+/// <summary>
+/// Represents the schedule model.
+/// </summary>
+public class ScheduleResponseModel
+{
+    /// <summary>
+    /// Gets or sets ISO-8601 formatted date-time for scheduled publishing.
+    /// </summary>
+    [JsonProperty("publish_time")]
+    public DateTime? PublishTime { get; set; }
+
+    /// <summary>
+    /// IANA time zone name used to display time offset of the scheduled publish date in the UI.
+    /// </summary>
+    [JsonProperty("publish_display_timezone")]
+    public string PublishDisplayTimeZone { get; set; }
+    
+    /// <summary>
+    /// Gets or sets ISO-8601 formatted date-time for scheduled unpublishing.
+    /// </summary>
+    [JsonProperty("unpublish_time")]
+    public DateTime? UnpublishTime { get; set; }
+
+    /// <summary>
+    /// IANA time zone name used to display time offset of the scheduled unpublish date in the UI.
+    /// </summary>
+    [JsonProperty("unpublish_display_timezone")]
+    public string UnpublishDisplayTimeZone { get; set; }
+}

--- a/Kontent.Ai.Management/Models/StronglyTyped/LanguageVariantModel.cs
+++ b/Kontent.Ai.Management/Models/StronglyTyped/LanguageVariantModel.cs
@@ -1,4 +1,5 @@
-﻿using Kontent.Ai.Management.Models.Shared;
+﻿using Kontent.Ai.Management.Models.Publishing;
+using Kontent.Ai.Management.Models.Shared;
 using Kontent.Ai.Management.Models.Workflow;
 using Newtonsoft.Json;
 using System;
@@ -33,6 +34,12 @@ public sealed class LanguageVariantModel<T> where T : new()
     /// </summary>
     [JsonProperty("last_modified")]
     public DateTime? LastModified { get; set; }
+
+    /// <summary>
+    /// Gets or sets the publishing and unpublishing schedule of the language variant.
+    /// </summary>
+    [JsonProperty("schedule")]
+    public ScheduleResponseModel Schedule { get; set; }
 
     /// <summary>
     /// Gets or sets workflow step identifier.

--- a/Kontent.Ai.Management/Modules/ModelBuilders/ModelProvider.cs
+++ b/Kontent.Ai.Management/Modules/ModelBuilders/ModelProvider.cs
@@ -20,6 +20,7 @@ internal class ModelProvider : IModelProvider
             Item = variant.Item,
             Language = variant.Language,
             LastModified = variant.LastModified,
+            Schedule = variant.Schedule,
             Workflow = variant.Workflow,
             Elements = _elementModelProvider.GetStronglyTypedElements<T>(variant.Elements)
         };


### PR DESCRIPTION
### Motivation

Adds readonly schedule object to content item variant, scheduled publish/unpublish times and display timezones.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
