### PR TITLE
EN-199 Add options for selecting entities to copy when cloning enviro…

### DIFF
--- a/Kontent.Ai.Management.Tests/CodeSamples/CmApiV2.cs
+++ b/Kontent.Ai.Management.Tests/CodeSamples/CmApiV2.cs
@@ -1665,6 +1665,10 @@ public class CmApiV2 : IClassFixture<FileSystemFixture>
             RolesToActivate = new[]
             {
                 Guid.Parse("2f925111-1457-49d4-a595-0958feae8ae4")
+            },
+            CopyDataOptions = new CopyDataOptions {
+                ContentItemsAssets = true,
+                ContentItemVersionHistory = false
             }
         });
 

--- a/Kontent.Ai.Management/Models/Environments/CopyDataOptions.cs
+++ b/Kontent.Ai.Management/Models/Environments/CopyDataOptions.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+
+namespace Kontent.Ai.Management.Models.Environments;
+
+/// <summary>
+/// Represents options for copying entities
+/// </summary>
+public class CopyDataOptions
+{
+    /// <summary>
+    /// Gets or sets an option to copy content items and assets.
+    /// </summary>
+    [JsonProperty("content_items_assets")]
+    public bool ContentItemsAssets { get; set; }
+
+    /// <summary>
+    /// Gets or sets an option to copy version history of content items.
+    /// </summary>
+    [JsonProperty("content_item_version_history")]
+    public bool ContentItemVersionHistory { get; set; }
+}

--- a/Kontent.Ai.Management/Models/Environments/EnvironmentCloneModel.cs
+++ b/Kontent.Ai.Management/Models/Environments/EnvironmentCloneModel.cs
@@ -20,4 +20,10 @@ public class EnvironmentCloneModel
     /// </summary>
     [JsonProperty("roles_to_activate")]
     public ICollection<Guid> RolesToActivate { get; set; }
+    
+    /// <sumary>
+    /// Gets or sets <see cref="Kontent.Ai.Management.Models.Environments.CopyDataOptions"/> for copying entities.
+    /// </sumary>
+    [JsonProperty("copy_data_options")]
+    public CopyDataOptions CopyDataOptions { get; set; }
 }


### PR DESCRIPTION
### Motivation

Clone-environment endpoint now has options to exclude content items & assets or content item version history.

### Checklist

- [/] Code follows coding conventions held in this repo
- [/] Automated tests have been added
- [/] Tests are passing
- [/] Docs have been updated (if applicable)
- [/] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Check that clone-environment with new copy data options works as expected.
