### PR TITLE
EN-207 Add asset folder codenames

### DIFF
--- a/Kontent.Ai.Management.Tests/Data/AssetFolder/Folder.json
+++ b/Kontent.Ai.Management.Tests/Data/AssetFolder/Folder.json
@@ -3,11 +3,13 @@
     {
       "id": "958001d8-2228-4373-b966-5262b5b96f71",
       "name": "Downloads",
+      "codename": "downloads",
       "external_id": "folder-with-downloadable-assets",
       "folders": [
         {
           "id": "9ca927b6-6e4d-4d6b-81e3-ec5e8f7772a0",
           "name": "Archives",
+          "codename": "archives",
           "external_id": "folder-with-downloadable-archives",
           "folders": []
         }
@@ -16,6 +18,7 @@
     {
       "id": "9ca927b6-6e4d-4d6b-81e3-ec5e8f7772a0",
       "name": "Legal documents",
+      "codename": "legal_documents",
       "external_id": "folder-documents",
       "folders": []
     }

--- a/Kontent.Ai.Management.Tests/ManagementClientTests/AssetFolderTests.cs
+++ b/Kontent.Ai.Management.Tests/ManagementClientTests/AssetFolderTests.cs
@@ -55,6 +55,7 @@ public class AssetFolderTests
                 {
                     ExternalId = "external-id",
                     Name= "name",
+                    Codename = "codename",
                     Folders = Enumerable.Empty<AssetFolderHierarchy>()
                 }
             }
@@ -114,6 +115,7 @@ public class AssetFolderTests
                 {
                     ExternalId = "external-id",
                     Name= "name",
+                    Codename = "codename",
                     Folders = Enumerable.Empty<AssetFolderHierarchy>()
                 },
                 Before = Reference.ByCodename("codename"),

--- a/Kontent.Ai.Management/Models/AssetFolders/AssetFolderHierarchy.cs
+++ b/Kontent.Ai.Management/Models/AssetFolders/AssetFolderHierarchy.cs
@@ -19,6 +19,12 @@ public sealed class AssetFolderHierarchy
     /// </summary>
     [JsonProperty("external_id", DefaultValueHandling = DefaultValueHandling.Ignore)]
     public string ExternalId { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the codename of the folder.
+    /// </summary>
+    [JsonProperty("codename", DefaultValueHandling = DefaultValueHandling.Ignore)]
+    public string Codename { get; set; }
 
     /// <summary>
     /// Gets or sets the name of the folder

--- a/Kontent.Ai.Management/Models/AssetFolders/AssetFolderLinkingHierarchy.cs
+++ b/Kontent.Ai.Management/Models/AssetFolders/AssetFolderLinkingHierarchy.cs
@@ -21,6 +21,12 @@ public sealed class AssetFolderLinkingHierarchy
     /// </summary>
     [JsonProperty("external_id", DefaultValueHandling = DefaultValueHandling.Ignore)]
     public string ExternalId { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the folder's codename.
+    /// </summary>
+    [JsonProperty("codename", DefaultValueHandling = DefaultValueHandling.Ignore)]
+    public string Codename { get; set; }
 
     /// <summary>
     /// Name of the folder


### PR DESCRIPTION
### Motivation

Adding support for asset folder codenames, so assets can be inserted into specific folder, referenced by its codename.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Try getting / adding asset folders with codenames, adding asset to a folder referenced by codename.
