### PR TITLE
add name property to taxonomy element

### DIFF
--- a/Kontent.Ai.Management/Models/Types/Elements/TaxonomyElementMetadataModel.cs
+++ b/Kontent.Ai.Management/Models/Types/Elements/TaxonomyElementMetadataModel.cs
@@ -10,6 +10,11 @@ namespace Kontent.Ai.Management.Models.Types.Elements;
 public class TaxonomyElementMetadataModel : ElementMetadataBase
 {
     /// <summary>
+    /// Gets or sets the element's display name.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+    /// <summary>
     /// Gets or sets a flag determining whether the element must be filled in.
     /// </summary>
     [JsonProperty("is_required")]


### PR DESCRIPTION
### Motivation

Fixes #268 

adds missing `name` property to `TaxonomyElementMetaDataModel`

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
