### PR TITLE
Add support for custom HTTP client, make ElementModelProvider public

### DIFF
--- a/Kontent.Ai.Management/ManagementClient.cs
+++ b/Kontent.Ai.Management/ManagementClient.cs
@@ -1,14 +1,14 @@
-﻿using Kontent.Ai.Management.Configuration;
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Kontent.Ai.Management.Configuration;
 using Kontent.Ai.Management.Models.Shared;
 using Kontent.Ai.Management.Modules.ActionInvoker;
 using Kontent.Ai.Management.Modules.HttpClient;
 using Kontent.Ai.Management.Modules.ModelBuilders;
 using Kontent.Ai.Management.Modules.ResiliencePolicy;
 using Kontent.Ai.Management.Modules.UrlBuilder;
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace Kontent.Ai.Management;
 
@@ -28,6 +28,16 @@ public sealed partial class ManagementClient : IManagementClient
     /// </summary>
     /// <param name="ManagementOptions">The settings of the Kontent.ai environment.</param>
     public ManagementClient(ManagementOptions ManagementOptions)
+        : this(ManagementOptions, new System.Net.Http.HttpClient())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ManagementClient"/> class for managing content of the specified environment.
+    /// </summary>
+    /// <param name="ManagementOptions">The settings of the Kontent.ai environment.</param>
+    /// <param name="httpClient">Custom HttpClient instance to use for HTTP requests.</param>
+    public ManagementClient(ManagementOptions ManagementOptions, System.Net.Http.HttpClient httpClient)
     {
         ArgumentNullException.ThrowIfNull(ManagementOptions);
 
@@ -49,7 +59,7 @@ public sealed partial class ManagementClient : IManagementClient
 
         _urlBuilder = new EndpointUrlBuilder(ManagementOptions);
         _actionInvoker = new ActionInvoker(
-            new ManagementHttpClient(new DefaultResiliencePolicyProvider(ManagementOptions.MaxRetryAttempts), ManagementOptions.EnableResilienceLogic),
+            new ManagementHttpClient(new Modules.HttpClient.HttpClient(httpClient), new DefaultResiliencePolicyProvider(ManagementOptions.MaxRetryAttempts), ManagementOptions.EnableResilienceLogic),
             new MessageCreator(ManagementOptions.ApiKey));
         _modelProvider = ManagementOptions.ModelProvider ?? new ModelProvider();
     }

--- a/Kontent.Ai.Management/Modules/HttpClient/HttpClient.cs
+++ b/Kontent.Ai.Management/Modules/HttpClient/HttpClient.cs
@@ -3,9 +3,13 @@ using System.Threading.Tasks;
 
 namespace Kontent.Ai.Management.Modules.HttpClient;
 
-internal class HttpClient : IHttpClient
+internal class HttpClient(System.Net.Http.HttpClient httpClient) : IHttpClient
 {
-    private readonly System.Net.Http.HttpClient _baseClient = new();
+    private readonly System.Net.Http.HttpClient _baseClient = httpClient;
+
+    public HttpClient() : this(new System.Net.Http.HttpClient())
+    {
+    }
 
     public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request) => await _baseClient.SendAsync(request);
 }

--- a/Kontent.Ai.Management/Modules/ModelBuilders/ElementModelProvider.cs
+++ b/Kontent.Ai.Management/Modules/ModelBuilders/ElementModelProvider.cs
@@ -7,8 +7,12 @@ using System.Reflection;
 
 namespace Kontent.Ai.Management.Modules.ModelBuilders;
 
-internal class ElementModelProvider : IElementModelProvider
+/// <summary>
+/// Provides methods for converting between dynamic and strongly-typed models.
+/// </summary>
+public class ElementModelProvider : IElementModelProvider
 {
+    /// <inheritdoc />
     public T GetStronglyTypedElements<T>(IEnumerable<dynamic> elements) where T : new()
     {
         var type = typeof(T);
@@ -30,6 +34,7 @@ internal class ElementModelProvider : IElementModelProvider
         return instance;
     }
 
+    /// <inheritdoc />
     public IEnumerable<dynamic> GetDynamicElements<T>(T stronglyTypedElements)
     {
         var type = typeof(T);

--- a/Kontent.Ai.Management/Modules/ModelBuilders/IElementModelProvider.cs
+++ b/Kontent.Ai.Management/Modules/ModelBuilders/IElementModelProvider.cs
@@ -13,7 +13,7 @@ public interface IElementModelProvider
     /// <typeparam name="T">Strongly typed elements model.</typeparam>
     /// <param name="elements">Dynamically typed element values</param>
     /// <returns>Strongly typed model of the element values.</returns>
-    public T GetStronglyTypedElements<T>(IEnumerable<dynamic> elements) where T : new();
+    T GetStronglyTypedElements<T>(IEnumerable<dynamic> elements) where T : new();
 
     /// <summary>
     /// Converts strongly typed element values model to dynamic model.
@@ -21,5 +21,5 @@ public interface IElementModelProvider
     /// <typeparam name="T">Strongly typed elements model.</typeparam>
     /// <param name="stronglyTypedElements">Strongly typed element values.</param>
     /// <returns>Dynamic element model values.</returns>
-    public IEnumerable<dynamic> GetDynamicElements<T>(T stronglyTypedElements);
+    IEnumerable<dynamic> GetDynamicElements<T>(T stronglyTypedElements);
 }

--- a/Kontent.Ai.Management/Modules/ModelBuilders/IElementModelProvider.cs
+++ b/Kontent.Ai.Management/Modules/ModelBuilders/IElementModelProvider.cs
@@ -5,7 +5,7 @@ namespace Kontent.Ai.Management.Modules.ModelBuilders;
 /// <summary>
 /// Defines the contract for mapping dynamic elements to strongly typed models.
 /// </summary>
-internal interface IElementModelProvider
+public interface IElementModelProvider
 {
     /// <summary>
     /// Builds a strongly typed element model from non-generic model.
@@ -13,7 +13,7 @@ internal interface IElementModelProvider
     /// <typeparam name="T">Strongly typed elements model.</typeparam>
     /// <param name="elements">Dynamically typed element values</param>
     /// <returns>Strongly typed model of the element values.</returns>
-    T GetStronglyTypedElements<T>(IEnumerable<dynamic> elements) where T : new();
+    public T GetStronglyTypedElements<T>(IEnumerable<dynamic> elements) where T : new();
 
     /// <summary>
     /// Converts strongly typed element values model to dynamic model.
@@ -21,5 +21,5 @@ internal interface IElementModelProvider
     /// <typeparam name="T">Strongly typed elements model.</typeparam>
     /// <param name="stronglyTypedElements">Strongly typed element values.</param>
     /// <returns>Dynamic element model values.</returns>
-    IEnumerable<dynamic> GetDynamicElements<T>(T stronglyTypedElements);
+    public IEnumerable<dynamic> GetDynamicElements<T>(T stronglyTypedElements);
 }


### PR DESCRIPTION
### Motivation

Fixes #270 #252 

Adds overloaded constructor to `ManagementClient` accepting a custom `HttpClient` object. Adjusts internal logic to propagate custom client to `ManagementHttpClient`. Also makes `ElementModelProvider` public for convenience (requested several times).

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
