### PR TITLE
EN-648 - Add spaces, collections, and publishing states filters to variant filter model

### DIFF
--- a/Kontent.Ai.Management.Tests/ManagementClientTests/ItemWithVariantTests.cs
+++ b/Kontent.Ai.Management.Tests/ManagementClientTests/ItemWithVariantTests.cs
@@ -173,6 +173,115 @@ public class ItemWithVariantTests : IClassFixture<FileSystemFixture>
     }
 
     [Fact]
+    public async Task FilterItemsWithVariantsAsync_WithSpacesFilter_ReturnsResults()
+    {
+        var client = _fileSystemFixture.CreateMockClientWithResponse("FilterResponse.json");
+
+        var request = new ItemWithVariantFilterRequestModel
+        {
+            Filters = new VariantFilterFiltersModel
+            {
+                Language = Reference.ByCodename("en-US"),
+                Spaces = new List<Reference>
+                {
+                    Reference.ByCodename("default"),
+                    Reference.ById(new Guid("4b628214-e4fe-4fe0-b1ff-955df33e1515"))
+                }
+            }
+        };
+
+        var response = await client.FilterItemsWithVariantsAsync(request);
+
+        response.Should().NotBeNull();
+        response.Should().BeAssignableTo<IListingResponseModel<ItemWithVariantFilterResultModel>>();
+        response.ToList().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task FilterItemsWithVariantsAsync_WithCollectionsFilter_ReturnsResults()
+    {
+        var client = _fileSystemFixture.CreateMockClientWithResponse("FilterResponse.json");
+
+        var request = new ItemWithVariantFilterRequestModel
+        {
+            Filters = new VariantFilterFiltersModel
+            {
+                Language = Reference.ByCodename("en-US"),
+                Collections = new List<Reference>
+                {
+                    Reference.ByCodename("default"),
+                    Reference.ByExternalId("external-collection-1")
+                }
+            }
+        };
+
+        var response = await client.FilterItemsWithVariantsAsync(request);
+
+        response.Should().NotBeNull();
+        response.Should().BeAssignableTo<IListingResponseModel<ItemWithVariantFilterResultModel>>();
+        response.ToList().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task FilterItemsWithVariantsAsync_WithPublishingStatesFilter_ReturnsResults()
+    {
+        var client = _fileSystemFixture.CreateMockClientWithResponse("FilterResponse.json");
+
+        var request = new ItemWithVariantFilterRequestModel
+        {
+            Filters = new VariantFilterFiltersModel
+            {
+                Language = Reference.ByCodename("en-US"),
+                PublishingStates = new List<VariantFilterPublishingState>
+                {
+                    VariantFilterPublishingState.Published,
+                    VariantFilterPublishingState.Unpublished
+                }
+            }
+        };
+
+        var response = await client.FilterItemsWithVariantsAsync(request);
+
+        response.Should().NotBeNull();
+        response.Should().BeAssignableTo<IListingResponseModel<ItemWithVariantFilterResultModel>>();
+        response.ToList().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task FilterItemsWithVariantsAsync_WithAllNewFilters_ReturnsResults()
+    {
+        var client = _fileSystemFixture.CreateMockClientWithResponse("FilterResponse.json");
+
+        var request = new ItemWithVariantFilterRequestModel
+        {
+            Filters = new VariantFilterFiltersModel
+            {
+                Language = Reference.ByCodename("en-US"),
+                Spaces = new List<Reference>
+                {
+                    Reference.ByCodename("default")
+                },
+                Collections = new List<Reference>
+                {
+                    Reference.ById(new Guid("4b628214-e4fe-4fe0-b1ff-955df33e1515"))
+                },
+                PublishingStates = new List<VariantFilterPublishingState>
+                {
+                    VariantFilterPublishingState.Published,
+                    VariantFilterPublishingState.Unpublished,
+                    VariantFilterPublishingState.NotPublishedYet
+                }
+            }
+        };
+
+        var response = await client.FilterItemsWithVariantsAsync(request);
+
+        response.Should().NotBeNull();
+        response.Should().BeAssignableTo<IListingResponseModel<ItemWithVariantFilterResultModel>>();
+        response.ToList().Should().HaveCount(2);
+    }
+
+    [Fact]
     public async Task BulkGetItemsWithVariantsAsync_WithValidRequest_ReturnsItemsWithVariants()
     {
         var client = _fileSystemFixture.CreateMockClientWithResponse("BulkGetResponse.json");

--- a/Kontent.Ai.Management/Models/VariantFilter/VariantFilterFiltersModel.cs
+++ b/Kontent.Ai.Management/Models/VariantFilter/VariantFilterFiltersModel.cs
@@ -56,4 +56,22 @@ public class VariantFilterFiltersModel
     /// </summary>
     [JsonProperty("taxonomy_groups")]
     public IEnumerable<VariantFilterTaxonomyGroupModel> TaxonomyGroups { get; set; }
+
+    /// <summary>
+    /// Gets or sets the spaces.
+    /// </summary>
+    [JsonProperty("spaces")]
+    public IEnumerable<Reference> Spaces { get; set; }
+
+    /// <summary>
+    /// Gets or sets the collections.
+    /// </summary>
+    [JsonProperty("collections")]
+    public IEnumerable<Reference> Collections { get; set; }
+
+    /// <summary>
+    /// Gets or sets the publishing states.
+    /// </summary>
+    [JsonProperty("publishing_states")]
+    public IEnumerable<VariantFilterPublishingState> PublishingStates { get; set; }
 }

--- a/Kontent.Ai.Management/Models/VariantFilter/VariantFilterPublishingState.cs
+++ b/Kontent.Ai.Management/Models/VariantFilter/VariantFilterPublishingState.cs
@@ -1,0 +1,27 @@
+using System.Runtime.Serialization;
+
+namespace Kontent.Ai.Management.Models.VariantFilter;
+
+/// <summary>
+/// Represents the publishing state of a content item variant.
+/// </summary>
+public enum VariantFilterPublishingState
+{
+    /// <summary>
+    /// The variant is published.
+    /// </summary>
+    [EnumMember(Value = "published")]
+    Published,
+
+    /// <summary>
+    /// The variant is unpublished.
+    /// </summary>
+    [EnumMember(Value = "unpublished")]
+    Unpublished,
+
+    /// <summary>
+    /// The variant has not been published yet.
+    /// </summary>
+    [EnumMember(Value = "not_published_yet")]
+    NotPublishedYet
+}


### PR DESCRIPTION
### Motivation

Extends VariantFilterFiltersModel with three new optional properties (Spaces, Collections, PublishingStates) for the POST /items-with-variant/filter endpoint. Adds a VariantFilterPublishingState enum following the existing VariantFilterCompletionStatus pattern. No breaking changes — all new properties are optional.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
