### PR TITLE
webspotlight sunset: set obsolete attributes and add RootItem property

### DIFF
--- a/Kontent.Ai.Management.Tests/Data/Space/ModifySpace_Replace_ModifiesSpace.json
+++ b/Kontent.Ai.Management.Tests/Data/Space/ModifySpace_Replace_ModifiesSpace.json
@@ -2,6 +2,9 @@
   "id": "ece703a9-900e-4781-9d21-bdfbf9762751",
   "codename": "new_space_codename",
   "name": "New space name",
+  "root_item": {
+    "id": "1024356f-858f-421a-b804-07c6bfe10ce5"
+  },
   "web_spotlight_root_item": {
     "id": "1024356f-858f-421a-b804-07c6bfe10ce5"
   },

--- a/Kontent.Ai.Management.Tests/Data/Space/Space.json
+++ b/Kontent.Ai.Management.Tests/Data/Space/Space.json
@@ -2,6 +2,9 @@
   "id": "ece703a9-900e-4781-9d21-bdfbf9762751",
   "codename": "space_1",
   "name": "Space 1",
+  "root_item": {
+    "id": "1024356f-858f-421a-b804-07c6bfe10ce5"
+  },
   "web_spotlight_root_item": {
     "id": "1024356f-858f-421a-b804-07c6bfe10ce5"
   },

--- a/Kontent.Ai.Management.Tests/Data/Space/Spaces.json
+++ b/Kontent.Ai.Management.Tests/Data/Space/Spaces.json
@@ -3,6 +3,9 @@
     "id": "ece703a9-900e-4781-9d21-bdfbf9762751",
     "codename": "space_1",
     "name": "Space 1",
+    "root_item": {
+      "id": "1024356f-858f-421a-b804-07c6bfe10ce5"
+    },
     "web_spotlight_root_item": {
       "id": "1024356f-858f-421a-b804-07c6bfe10ce5"
     }
@@ -11,6 +14,9 @@
     "id": "191bdf9f-c885-44e5-83de-6ea5131f9c86",
     "codename": "space_2",
     "name": "Space 2",
+    "root_item": {
+      "id": "ce25965c-337f-4bd3-a68b-5870eeade9e5"
+    },
     "web_spotlight_root_item": {
       "id": "ce25965c-337f-4bd3-a68b-5870eeade9e5"
     }
@@ -19,6 +25,7 @@
     "id": "191bdf9f-c885-44e5-83de-6ea5131f9c86",
     "codename": "space_3",
     "name": "Space 3",
+    "root_item": null,
     "web_spotlight_root_item": null
   }
 ]

--- a/Kontent.Ai.Management.Tests/Data/WebSpotlight/ActivationWebSpotlightResponse.json
+++ b/Kontent.Ai.Management.Tests/Data/WebSpotlight/ActivationWebSpotlightResponse.json
@@ -1,4 +1,6 @@
 {
-  "enabled": true,
-  "root_type": "0689fcb3-24f1-49f4-b115-e7b816d59e9d"
+  "enabled": false,
+  "root_type": null,
+  "deprecated": true,
+  "message": "Web Spotlight has been sunset. Please use Live Preview instead: https://kontent.ai/learn/docs/preview"
 }

--- a/Kontent.Ai.Management.Tests/Data/WebSpotlight/ActivationWebSpotlightWithProvidedRootTypeIdResponse.json
+++ b/Kontent.Ai.Management.Tests/Data/WebSpotlight/ActivationWebSpotlightWithProvidedRootTypeIdResponse.json
@@ -1,4 +1,6 @@
 {
-  "enabled": true,
-  "root_type": "3660e894-bae8-4dcd-9d3e-5fc9205c2ece"
+  "enabled": false,
+  "root_type": null,
+  "deprecated": true,
+  "message": "Web Spotlight has been sunset. Please use Live Preview instead: https://kontent.ai/learn/docs/preview"
 }

--- a/Kontent.Ai.Management.Tests/Data/WebSpotlight/DeactivationWebSpotlightResponse.json
+++ b/Kontent.Ai.Management.Tests/Data/WebSpotlight/DeactivationWebSpotlightResponse.json
@@ -1,4 +1,6 @@
 {
   "enabled": false,
-  "root_type": "0689fcb3-24f1-49f4-b115-e7b816d59e9d"
+  "root_type": null,
+  "deprecated": true,
+  "message": "Web Spotlight has been sunset. Please use Live Preview instead: https://kontent.ai/learn/docs/preview"
 }

--- a/Kontent.Ai.Management.Tests/Data/WebSpotlight/GetStatusWebSpotlightResponse.json
+++ b/Kontent.Ai.Management.Tests/Data/WebSpotlight/GetStatusWebSpotlightResponse.json
@@ -1,4 +1,6 @@
 {
-  "enabled": true,
-  "root_type": "0689fcb3-24f1-49f4-b115-e7b816d59e9d"
+  "enabled": false,
+  "root_type": null,
+  "deprecated": true,
+  "message": "Web Spotlight has been sunset. Please use Live Preview instead: https://kontent.ai/learn/docs/preview"
 }

--- a/Kontent.Ai.Management.Tests/ManagementClientTests/SpaceTests.cs
+++ b/Kontent.Ai.Management.Tests/ManagementClientTests/SpaceTests.cs
@@ -8,6 +8,8 @@ using System.Net.Http;
 using Xunit;
 using static Kontent.Ai.Management.Tests.Base.Scenario;
 
+#pragma warning disable CS0618 // WebSpotlightRootItem is obsolete; these tests intentionally exercise it for backward compatibility.
+
 namespace Kontent.Ai.Management.Tests.ManagementClientTests;
 
 public class SpaceTests : IClassFixture<FileSystemFixture>
@@ -23,6 +25,7 @@ public class SpaceTests : IClassFixture<FileSystemFixture>
         var createModel = new SpaceCreateModel {
             Codename = expected.Codename,
             Name = expected.Name,
+            RootItem = expected.RootItem,
             WebSpotlightRootItem = expected.WebSpotlightRootItem,
             Collections = expected.Collections
         };
@@ -35,6 +38,38 @@ public class SpaceTests : IClassFixture<FileSystemFixture>
             .Response(response)
             .Url(SpacesBaseUrl)
             .Validate();
+    }
+
+    [Fact]
+    public async void CreateSpace_WithRootItem_SerializesRootItem()
+    {
+        var client = _scenario.WithResponses("Space.json").CreateManagementClient();
+        var createModel = new SpaceCreateModel
+        {
+            Codename = "space_1",
+            Name = "Space 1",
+            RootItem = Reference.ById(Guid.Parse("1024356f-858f-421a-b804-07c6bfe10ce5"))
+        };
+
+        await client.CreateSpaceAsync(createModel);
+
+        _scenario.CreateExpectations()
+            .HttpMethod(HttpMethod.Post)
+            .RequestPayload(createModel)
+            .Url(SpacesBaseUrl)
+            .Validate();
+    }
+
+    [Fact]
+    public async void GetSpace_RootItemAndWebSpotlightRootItem_HaveSameValue()
+    {
+        var client = _scenario.WithResponses("Space.json").CreateManagementClient();
+        var identifier = Reference.ById(Guid.NewGuid());
+
+        var response = await client.GetSpaceAsync(identifier);
+
+        response.RootItem.Should().BeEquivalentTo(response.WebSpotlightRootItem);
+        response.RootItem.Id.Should().Be(Guid.Parse("1024356f-858f-421a-b804-07c6bfe10ce5"));
     }
 
     [Fact]
@@ -114,6 +149,26 @@ public class SpaceTests : IClassFixture<FileSystemFixture>
         };
 
         var response =  await client.ModifySpaceAsync(identifier, changes);
+
+        _scenario.CreateExpectations()
+            .HttpMethod(HttpMethod.Patch)
+            .RequestPayload(changes)
+            .Response(response)
+            .Url(SpacesBaseUrl + $"/{identifier.Id}")
+            .Validate();
+    }
+
+    [Fact]
+    public async void ModifySpace_Replace_RootItem_ModifiesSpace()
+    {
+        var client = _scenario.WithResponses("ModifySpace_Replace_ModifiesSpace.json").CreateManagementClient();
+        var identifier = Reference.ById(Guid.NewGuid());
+        var changes = new SpaceOperationReplaceModel[]
+        {
+            new() { PropertyName = PropertyName.RootItem, Value = Reference.ById(Guid.Parse("1024356f-858f-421a-b804-07c6bfe10ce5")) }
+        };
+
+        var response = await client.ModifySpaceAsync(identifier, changes);
 
         _scenario.CreateExpectations()
             .HttpMethod(HttpMethod.Patch)

--- a/Kontent.Ai.Management.Tests/ManagementClientTests/WebSpotlightTests.cs
+++ b/Kontent.Ai.Management.Tests/ManagementClientTests/WebSpotlightTests.cs
@@ -1,10 +1,13 @@
-﻿using Kontent.Ai.Management.Models.Shared;
+using FluentAssertions;
+using Kontent.Ai.Management.Models.Shared;
 using Kontent.Ai.Management.Models.WebSpotlight;
 using Kontent.Ai.Management.Tests.Base;
 using System;
 using System.Net.Http;
 using Xunit;
 using static Kontent.Ai.Management.Tests.Base.Scenario;
+
+#pragma warning disable CS0618 // Web Spotlight members are obsolete; these tests intentionally exercise them for backward compatibility.
 
 namespace Kontent.Ai.Management.Tests.ManagementClientTests;
 
@@ -14,7 +17,7 @@ public class WebSpotlightTests : IClassFixture<FileSystemFixture>
     private readonly Scenario _scenario = new(folder: "WebSpotlight");
 
     [Fact]
-    public async void ActivateWebSpotlight_Returns_EnabledStatusAndRootTypeId()
+    public async void ActivateWebSpotlight_Returns_DeprecatedStatus()
     {
         var client = _scenario
             .WithResponses("ActivationWebSpotlightResponse.json")
@@ -25,6 +28,9 @@ public class WebSpotlightTests : IClassFixture<FileSystemFixture>
         var response = await client
             .ActivateWebSpotlightAsync(webSpotlightActivateModel);
 
+        response.Enabled.Should().BeFalse();
+        response.RootTypeId.Should().BeNull();
+
         _scenario
             .CreateExpectations()
             .HttpMethod(HttpMethod.Put)
@@ -34,7 +40,7 @@ public class WebSpotlightTests : IClassFixture<FileSystemFixture>
     }
 
     [Fact]
-    public async void ActivateWebSpotlight_WithProvidedValidRootTypeById_Returns_EnabledStatusAndRootTypeId()
+    public async void ActivateWebSpotlight_WithProvidedValidRootTypeById_SerializesRequest()
     {
         var client = _scenario
             .WithResponses("ActivationWebSpotlightWithProvidedRootTypeIdResponse.json")
@@ -53,9 +59,9 @@ public class WebSpotlightTests : IClassFixture<FileSystemFixture>
             .Url(WebSpotlightBaseUrl)
             .Validate();
     }
-    
+
     [Fact]
-    public async void ActivateWebSpotlight_WithProvidedValidRootTypeByCodename_Returns_EnabledStatusAndRootTypeId()
+    public async void ActivateWebSpotlight_WithProvidedValidRootTypeByCodename_SerializesRequest()
     {
         var client = _scenario
             .WithResponses("ActivationWebSpotlightWithProvidedRootTypeIdResponse.json")
@@ -76,7 +82,7 @@ public class WebSpotlightTests : IClassFixture<FileSystemFixture>
     }
 
     [Fact]
-    public async void DeactivateWebSpotlight_Returns_DisabledStatusAndRootTypeId()
+    public async void DeactivateWebSpotlight_Returns_DeprecatedStatus()
     {
         var client = _scenario
             .WithResponses("DeactivationWebSpotlightResponse.json")
@@ -84,6 +90,9 @@ public class WebSpotlightTests : IClassFixture<FileSystemFixture>
 
         var response = await client
             .DeactivateWebSpotlightAsync();
+
+        response.Enabled.Should().BeFalse();
+        response.RootTypeId.Should().BeNull();
 
         _scenario
             .CreateExpectations()
@@ -94,7 +103,7 @@ public class WebSpotlightTests : IClassFixture<FileSystemFixture>
     }
 
     [Fact]
-    public async void GetWebSpotlightStatus_Returns_StatusAndRootTypeId()
+    public async void GetWebSpotlightStatus_Returns_DeprecatedStatus()
     {
         var client = _scenario
             .WithResponses("GetStatusWebSpotlightResponse.json")
@@ -102,6 +111,9 @@ public class WebSpotlightTests : IClassFixture<FileSystemFixture>
 
         var response = await client
             .GetWebSpotlightStatusAsync();
+
+        response.Enabled.Should().BeFalse();
+        response.RootTypeId.Should().BeNull();
 
         _scenario
             .CreateExpectations()

--- a/Kontent.Ai.Management/IManagementClient.cs
+++ b/Kontent.Ai.Management/IManagementClient.cs
@@ -789,21 +789,27 @@ public interface IManagementClient
 
     /// <summary>
     /// Activates the web spotlight, allowing you to specify an existing Root Type ID.
+    /// Web Spotlight has been sunset and this endpoint is now a no-op that always returns a deprecated status. Use Live Preview instead: https://kontent.ai/learn/docs/preview.
     /// </summary>
     /// <param name="webSpotlightActivateModel">Represents configuration that will be used for web spotlight activation.</param>
     /// <returns>A <see cref="WebSpotlightModel"/> instance representing the web spotlight status.</returns>
+    [Obsolete("Web Spotlight has been sunset. Use Live Preview instead.")]
     Task<WebSpotlightModel> ActivateWebSpotlightAsync(WebSpotlightActivateModel webSpotlightActivateModel);
 
     /// <summary>
     /// Deactivates the web spotlight.
+    /// Web Spotlight has been sunset and this endpoint is now a no-op that always returns a deprecated status. Use Live Preview instead: https://kontent.ai/learn/docs/preview.
     /// </summary>
     /// <returns>A <see cref="WebSpotlightModel"/> instance representing the web spotlight status.</returns>
+    [Obsolete("Web Spotlight has been sunset. Use Live Preview instead.")]
     Task<WebSpotlightModel> DeactivateWebSpotlightAsync();
 
     /// <summary>
     /// Returns the web spotlight status.
+    /// Web Spotlight has been sunset and this endpoint is now a no-op that always returns a deprecated status. Use Live Preview instead: https://kontent.ai/learn/docs/preview.
     /// </summary>
     /// <returns>A <see cref="WebSpotlightModel"/> instance representing the web spotlight status.</returns>
+    [Obsolete("Web Spotlight has been sunset. Use Live Preview instead.")]
     Task<WebSpotlightModel> GetWebSpotlightStatusAsync();
 
     /// <summary>

--- a/Kontent.Ai.Management/ManagementClient.WebSpotlight.cs
+++ b/Kontent.Ai.Management/ManagementClient.WebSpotlight.cs
@@ -11,6 +11,7 @@ namespace Kontent.Ai.Management;
 public partial class ManagementClient
 {
     /// <inheritdoc />
+    [Obsolete("Web Spotlight has been sunset. Use Live Preview instead.")]
     public async Task<WebSpotlightModel> ActivateWebSpotlightAsync(WebSpotlightActivateModel webSpotlightActivateModel)
     {
         ArgumentNullException.ThrowIfNull(webSpotlightActivateModel);
@@ -20,6 +21,7 @@ public partial class ManagementClient
     }
 
     /// <inheritdoc />
+    [Obsolete("Web Spotlight has been sunset. Use Live Preview instead.")]
     public async Task<WebSpotlightModel> DeactivateWebSpotlightAsync()
     {
         var endpointUrl = _urlBuilder.BuildWebSpotlightUrl();
@@ -27,6 +29,7 @@ public partial class ManagementClient
     }
     
     /// <inheritdoc />
+    [Obsolete("Web Spotlight has been sunset. Use Live Preview instead.")]
     public async Task<WebSpotlightModel> GetWebSpotlightStatusAsync()
     {
         var endpointUrl = _urlBuilder.BuildWebSpotlightUrl();

--- a/Kontent.Ai.Management/Models/Spaces/Patch/PropertyName.cs
+++ b/Kontent.Ai.Management/Models/Spaces/Patch/PropertyName.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 
 namespace Kontent.Ai.Management.Models.Spaces.Patch;
@@ -20,8 +21,15 @@ public enum PropertyName
     Name,
     
     /// <summary>
-    /// The web spotlight root item of the space.
+    /// The root item of the space. Both this and <see cref="WebSpotlightRootItem"/> target the same root item.
     /// </summary>
+    [EnumMember(Value = "root_item")]
+    RootItem,
+
+    /// <summary>
+    /// The web spotlight root item of the space. Both this and <see cref="RootItem"/> target the same root item.
+    /// </summary>
+    [Obsolete("Use root_item instead.")]
     [EnumMember(Value = "web_spotlight_root_item")]
     WebSpotlightRootItem,
 

--- a/Kontent.Ai.Management/Models/Spaces/SpaceCreateModel.cs
+++ b/Kontent.Ai.Management/Models/Spaces/SpaceCreateModel.cs
@@ -1,5 +1,6 @@
 using Kontent.Ai.Management.Models.Shared;
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace Kontent.Ai.Management.Models.Spaces;
@@ -14,16 +15,25 @@ public class SpaceCreateModel
     /// </summary>
     [JsonProperty("name")]
     public string Name { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the space's codename.
     /// </summary>
     [JsonProperty("codename")]
     public string Codename { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the space's root item.
+    /// If both <see cref="RootItem"/> and <see cref="WebSpotlightRootItem"/> are set, <see cref="RootItem"/> takes precedence.
     /// </summary>
+    [JsonProperty("root_item")]
+    public Reference RootItem { get; set; }
+
+    /// <summary>
+    /// Gets or sets the space's root item.
+    /// If both <see cref="RootItem"/> and <see cref="WebSpotlightRootItem"/> are set, <see cref="RootItem"/> takes precedence.
+    /// </summary>
+    [Obsolete("Use root_item instead.")]
     [JsonProperty("web_spotlight_root_item")]
     public Reference WebSpotlightRootItem { get; set; }
 

--- a/Kontent.Ai.Management/Models/Spaces/SpaceModel.cs
+++ b/Kontent.Ai.Management/Models/Spaces/SpaceModel.cs
@@ -30,7 +30,16 @@ public class SpaceModel
 
     /// <summary>
     /// Gets or sets the space's root item.
+    /// Both <see cref="RootItem"/> and <see cref="WebSpotlightRootItem"/> are returned and carry the same value.
     /// </summary>
+    [JsonProperty("root_item")]
+    public Reference RootItem { get; set; }
+
+    /// <summary>
+    /// Gets or sets the space's root item.
+    /// Both <see cref="RootItem"/> and <see cref="WebSpotlightRootItem"/> are returned and carry the same value.
+    /// </summary>
+    [Obsolete("Use root_item instead.")]
     [JsonProperty("web_spotlight_root_item")]
     public Reference WebSpotlightRootItem { get; set; }
 

--- a/Kontent.Ai.Management/Models/WebSpotlight/WebSpotlightModel.cs
+++ b/Kontent.Ai.Management/Models/WebSpotlight/WebSpotlightModel.cs
@@ -9,13 +9,13 @@ namespace Kontent.Ai.Management.Models.WebSpotlight;
 public class WebSpotlightModel
 {
     /// <summary>
-    /// Gets or sets the web spotlight's Enabled.
+    /// Gets or sets the web spotlight's Enabled. Always false because Web Spotlight has been sunset.
     /// </summary>
     [JsonProperty("enabled")]
     public bool Enabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the web spotlight's Root Type ID.
+    /// Gets or sets the web spotlight's Root Type ID. Always null because Web Spotlight has been sunset.
     /// </summary>
     [JsonProperty("root_type")]
     public Guid? RootTypeId { get; set; }


### PR DESCRIPTION
### Motivation

KCL-14766 The Management API shipped two changes the SDK needs to reflect:

1. **Web Spotlight sunset.** The feature was replaced by Live Preview. The three web spotlight endpoints (activate, deactivate, status) still exist but are now no-ops returning a static 200 body. They stay callable for backward compatibility but are marked `[Obsolete]` so consumers get a compile time nudge toward Live Preview.

2. **Generic root_item on Spaces.** A feature neutral `root_item` reference replaces the Web Spotlight specific `web_spotlight_root_item`. The old property still works and will be removed in the next major version. Backend semantics:
   * On create: if both are set, `root_item` wins (`root_item ?? web_spotlight_root_item`).
   * On response: both fields are returned and carry the same value.
   * On PATCH: the property path accepts both `web_spotlight_root_item` and `root_item`, targeting the same root item.

These are additive plus deprecations only. No routes changed, no obsolete members removed.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (in progress)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

No manual testing required. Model and serialization changes only, covered by unit tests.