### PR TITLE
SE-338 - Sanitize URL identifiers

### DIFF
--- a/Kontent.Ai.Management.Tests/ManagementClientTests/EnvironmentUserTests.cs
+++ b/Kontent.Ai.Management.Tests/ManagementClientTests/EnvironmentUserTests.cs
@@ -97,7 +97,7 @@ public class EnvironmentUserTests : IClassFixture<FileSystemFixture>
             .CreateExpectations()
             .HttpMethod(HttpMethod.Put)
             .Response(response)
-            .Url($"{Endpoint}/projects/{ENVIRONMENT_ID}/users/email/{identifier.Email}/roles")
+            .Url($"{Endpoint}/projects/{ENVIRONMENT_ID}/users/email/{System.Uri.EscapeDataString(identifier.Email)}/roles")
             .Validate();
     }
 

--- a/Kontent.Ai.Management.Tests/Modules/UrlBuilder/IdentifierSegmentSafetyTests.cs
+++ b/Kontent.Ai.Management.Tests/Modules/UrlBuilder/IdentifierSegmentSafetyTests.cs
@@ -1,0 +1,68 @@
+using Kontent.Ai.Management.Models.Shared;
+using System;
+using Xunit;
+
+namespace Kontent.Ai.Management.Tests.Modules.UrlBuilder;
+
+// A caller-supplied identifier (codename, external id, email, upload file name) becomes a URL path segment. Left raw,
+// a value such as "../../webhooks" is normalized by System.Uri before the request is sent and retargets the call to a
+// different Management API endpoint under the same API key. These tests pin that the offending characters are escaped
+// or rejected at the URL-building layer so the request can never leave its intended segment.
+public partial class EndpointUrlBuilderTests
+{
+    [Theory]
+    [InlineData("../../webhooks", "..%2F..%2Fwebhooks")]
+    [InlineData("a/b", "a%2Fb")]
+    [InlineData("a\\b", "a%5Cb")]
+    public void BuildItemUrl_Codename_EscapesPathSeparators(string codename, string escaped)
+    {
+        var actual = _builder.BuildItemUrl(Reference.ByCodename(codename));
+        Assert.Equal($"{ENDPOINT}/projects/{ENVIRONMENT_ID}/items/codename/{escaped}", actual);
+    }
+
+    [Theory]
+    [InlineData("../../webhooks", "..%2F..%2Fwebhooks")]
+    [InlineData("a/b", "a%2Fb")]
+    public void BuildItemUrl_ExternalId_EscapesPathSeparators(string externalId, string escaped)
+    {
+        var actual = _builder.BuildItemUrl(Reference.ByExternalId(externalId));
+        Assert.Equal($"{ENDPOINT}/projects/{ENVIRONMENT_ID}/items/external-id/{escaped}", actual);
+    }
+
+    [Fact]
+    public void BuildModifyUsersRoleUrl_Email_EscapesPathSeparators()
+    {
+        var actual = _builder.BuildModifyUsersRoleUrl(UserIdentifier.ByEmail("../../subscription"));
+        Assert.Equal($"{ENDPOINT}/projects/{ENVIRONMENT_ID}/users/email/..%2F..%2Fsubscription/roles", actual);
+    }
+
+    [Fact]
+    public void BuildUploadFileUrl_EscapesPathSeparators()
+    {
+        var actual = _builder.BuildUploadFileUrl("../../webhooks");
+        Assert.Equal($"{ENDPOINT}/projects/{ENVIRONMENT_ID}/files/..%2F..%2Fwebhooks", actual);
+    }
+
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    public void BuildItemUrl_Codename_RejectsDotSegments(string codename)
+    {
+        Assert.Throws<ArgumentException>(() => _builder.BuildItemUrl(Reference.ByCodename(codename)));
+    }
+
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    public void BuildUploadFileUrl_RejectsDotSegments(string fileName)
+    {
+        Assert.Throws<ArgumentException>(() => _builder.BuildUploadFileUrl(fileName));
+    }
+
+    [Fact]
+    public void BuildItemUrl_OrdinaryCodename_IsUnchanged()
+    {
+        var actual = _builder.BuildItemUrl(Reference.ByCodename("which_brewing_fits_you"));
+        Assert.Equal($"{ENDPOINT}/projects/{ENVIRONMENT_ID}/items/codename/which_brewing_fits_you", actual);
+    }
+}

--- a/Kontent.Ai.Management.Tests/Modules/UrlBuilder/ProjectUserTests.cs
+++ b/Kontent.Ai.Management.Tests/Modules/UrlBuilder/ProjectUserTests.cs
@@ -20,7 +20,7 @@ public partial class EndpointUrlBuilderTests
     public void BuildModifyUsersRoleUrl_WithEmail_ReturnsExpectedUrl()
     {
         var email = "test@test.test";
-        var expectedResult = $"{ENDPOINT}/projects/{ENVIRONMENT_ID}/users/email/{email}/roles";
+        var expectedResult = $"{ENDPOINT}/projects/{ENVIRONMENT_ID}/users/email/{System.Uri.EscapeDataString(email)}/roles";
         var actualResult = _builder.BuildModifyUsersRoleUrl(UserIdentifier.ByEmail(email));
 
         Assert.Equal(expectedResult, actualResult);

--- a/Kontent.Ai.Management.Tests/Modules/UrlBuilder/SubscriptionTests.cs
+++ b/Kontent.Ai.Management.Tests/Modules/UrlBuilder/SubscriptionTests.cs
@@ -42,7 +42,7 @@ public partial class EndpointUrlBuilderTests
         var userIdentifier = UserIdentifier.ByEmail("test@test.test");
 
         var actualUrl = _builder.BuildSubscriptionUserUrl(userIdentifier);
-        var expectedUrl = $"{ENDPOINT}/subscriptions/{SUBSCRIPTION_ID}/users/email/{userIdentifier.Email}";
+        var expectedUrl = $"{ENDPOINT}/subscriptions/{SUBSCRIPTION_ID}/users/email/{System.Uri.EscapeDataString(userIdentifier.Email)}";
 
         Assert.Equal(expectedUrl, actualUrl);
     }

--- a/Kontent.Ai.Management/Modules/Extensions/UrlTemplateExtensions.cs
+++ b/Kontent.Ai.Management/Modules/Extensions/UrlTemplateExtensions.cs
@@ -1,22 +1,24 @@
-﻿using Kontent.Ai.Management.Models.Shared;
-using Kontent.Ai.Management.Modules.UrlBuilder.Templates;
 using System;
-using System.Net;
+using Kontent.Ai.Management.Models.Shared;
+using Kontent.Ai.Management.Modules.UrlBuilder.Templates;
 
 namespace Kontent.Ai.Management.Modules.Extensions;
 
 internal static class UrlTemplateExtensions
 {
-    internal static string GetIdentifierUrlSegment(this UrlTemplate template, UserIdentifier identifier)
+    internal static string GetIdentifierUrlSegment(
+        this UrlTemplate template,
+        UserIdentifier identifier
+    )
     {
         if (identifier.Id != null)
         {
-            return string.Format(template.UrlId, identifier.Id);
+            return string.Format(template.UrlId, ToSafePathSegment(identifier.Id));
         }
 
         if (!string.IsNullOrEmpty(identifier.Email))
         {
-            return string.Format(template.UrlEmail, identifier.Email);
+            return string.Format(template.UrlEmail, ToSafePathSegment(identifier.Email));
         }
 
         throw new ArgumentException("You must provide user id or email");
@@ -31,15 +33,23 @@ internal static class UrlTemplateExtensions
 
         if (!string.IsNullOrEmpty(identifier.Codename))
         {
-            return string.Format(template.UrlCodename, identifier.Codename);
+            return string.Format(template.UrlCodename, ToSafePathSegment(identifier.Codename));
         }
 
         if (!string.IsNullOrEmpty(identifier.ExternalId))
         {
-            var escapedExternalId = WebUtility.UrlEncode(identifier.ExternalId);
-            return string.Format(template.UrlExternalId, escapedExternalId);
+            return string.Format(template.UrlExternalId, ToSafePathSegment(identifier.ExternalId));
         }
 
         throw new ArgumentException("You must provide id, codename or externalId");
     }
+
+    /// <summary>
+    /// Escapes and validates a caller-supplied identifier (codename, external id, email, or upload file name) so it
+    /// stays a single URL path segment. Prevents path traversal attacks.
+    /// </summary>
+    internal static string ToSafePathSegment(string value) =>
+        value is "." or ".."
+            ? throw new ArgumentException($"'{value}' is not a valid identifier.", nameof(value))
+            : Uri.EscapeDataString(value);
 }

--- a/Kontent.Ai.Management/Modules/UrlBuilder/EndpointUrlBuilder.cs
+++ b/Kontent.Ai.Management/Modules/UrlBuilder/EndpointUrlBuilder.cs
@@ -165,7 +165,7 @@ internal sealed class EndpointUrlBuilder
 
     public string BuildAssetsUrl(Reference identifier) => GetEnvironmentUrl(_assetTemplate.GetIdentifierUrlSegment(identifier));
 
-    public string BuildUploadFileUrl(string fileName) => GetEnvironmentUrl(string.Format(URL_TEMPLATE_FILE_FILENAME, fileName));
+    public string BuildUploadFileUrl(string fileName) => GetEnvironmentUrl(string.Format(URL_TEMPLATE_FILE_FILENAME, UrlTemplateExtensions.ToSafePathSegment(fileName)));
 
     public string BuildAssetRenditionsUrl(Reference assetIdentifier) => GetEnvironmentUrl(
         string.Concat(


### PR DESCRIPTION
### Motivation

Guards identifier values (codenames, external ids, file names) against path traversal, so a value like `../` can't retarget the request to another endpoint. More info in [SE-338](https://kontent-ai.atlassian.net/browse/SE-338?focusedCommentId=641355&sourceType=mention)

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
