### PR TITLE
Harden workflow checkout and modernize action versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +58,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,6 +71,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -14,9 +14,11 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 8.0.x
       - name: Restore dependencies
@@ -27,4 +29,4 @@ jobs:
         run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
       - name: Codecov
         if: ${{ runner.os == 'Linux' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,11 @@ jobs:
       id-token: write   # Required for OIDC token issuance
       contents: write   # Required for uploading release assets
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 8.0.x
       - name: Extract version from tag
@@ -29,11 +31,11 @@ jobs:
       - name: Test
         run: dotnet test --no-build --verbosity normal --configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
       - name: Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
       - name: Pack
         run: dotnet pack --no-build --include-symbols --verbosity normal --configuration Release --output ./artifacts /p:PackageVersion="${{ steps.get_version.outputs.version-without-v }}"
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "NuGet packages"
           path: ./artifacts


### PR DESCRIPTION
Workflow-only change. Clears the Aikido "persist Git credentials" findings and brings the pinned actions up to their current majors.

## persist-credentials

`actions/checkout` writes a credential into `.git/config` by default, leaving it readable by every later step in the job. Set `persist-credentials: false` on **all 3 checkout steps**.

Safe here — verified before changing anything:

- No workflow runs `git push`, `git commit`, `git tag` or `git config`
- No auto-commit / create-pull-request style actions
- `release.yml` passes `GH_TOKEN` explicitly to `gh release upload`, which uses the token directly and never touches the persisted git credential
- No submodules, no `ssh-key:`, no `token:` override on any checkout step

This repo was the furthest behind — `codeql.yml` and `integrate.yml` were still on `actions/checkout@v3` and `github/codeql-action@v2`, both running on the long-deprecated Node 16 runtime. Versions were also inconsistent between workflows (`codecov-action` at v3 in one file and v5 in another); this unifies them.

## Action versions

| Action | From | To |
|---|---|---|
| `actions/checkout` | v3, v4 | **v7** |
| `actions/setup-dotnet` | v3, v4 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `codecov/codecov-action` | v3, v5 | **v7** |
| `github/codeql-action` | v2 | **v4** |

11 `uses:` pins updated in total. These majors are Node 20 → Node 24 runtime moves requiring Actions Runner ≥ 2.327.1. Every job here runs on GitHub-hosted runners (`ubuntu-latest` / `windows-latest` / `macos-latest`), which are already past that, so no runner-side change is needed.

## Verification

- Every modified workflow parses as valid YAML
- Diff reviewed for all three indentation shapes in these files (bare `- uses:`, nested `- uses:`, and `uses:` under a `name:` with an existing `with:` block)

> Note: `release.yml` only triggers on `release: published`, so neither this PR's checks nor a merge to `master` will exercise it. Its changes are the same mechanical edit as the others, but they go unexercised until the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
